### PR TITLE
update dome docs to latest install method

### DIFF
--- a/source/dome/gettingstarted.md
+++ b/source/dome/gettingstarted.md
@@ -4,7 +4,7 @@
 
 Dome is available as a `.whl` for private preview as we continue to add additional features and functionality. Please contact us if you're interested in trying out Dome. 
 
-Once you are granted access, you will recieve 
+Dome uses our in-house library `vijil-core`, for various functionalities. If you are interested in trying out Dome, please contact us to recieve access. Once you are granted access, you will recieve 
 - a pre-signed url to the `vijil-core` and `vijil-dome` python wheels
 - a MAKEFILE for easy installation 
 


### PR DESCRIPTION
Older install method for dome would break due to a local file path reference and also contained duplicated files due to overlaps in core and dome. 
Install now uses one wheel for core and another for dome, which solves both issues