### PR TITLE
Add auto-generated api tags

### DIFF
--- a/source/api.md
+++ b/source/api.md
@@ -4,4 +4,7 @@
 ```{eval-rst}
 .. openapi::  openapi.yaml
    :group:
+   :exclude:
+      /healthz
+      /metrics
 ```

--- a/source/api.md
+++ b/source/api.md
@@ -4,7 +4,4 @@
 ```{eval-rst}
 .. openapi::  openapi.yaml
    :group:
-   :exclude:
-      /healthz
-      /metrics
 ```

--- a/source/openapi.yaml
+++ b/source/openapi.yaml
@@ -22,6 +22,8 @@ paths:
                 title: Response Health Check Healthz Get
   /metrics:
     get:
+      tags:
+        - Monitoring
       summary: Metrics
       operationId: metrics_metrics_get
       responses:


### PR DESCRIPTION
Add API tags auto-generated from FastAPI (previous ones were manually applied) and ordered/organized better for readability.

@shubhobm I accidentally pushed the f[irst part](https://github.com/vijilAI/docs/commit/b1f97abb116cf14e3a93e33d53b8383ae0fa824b) of this change to Main, this commit is updating the openapi spec to the latest auto-generated version.

#80 