### PR TITLE
docs: Add Agent Developer Guide with SDK and API reference

### DIFF
--- a/developer-guide/api/agents-api.mdx
+++ b/developer-guide/api/agents-api.mdx
@@ -1,0 +1,448 @@
+---
+title: 'Agents API'
+description: 'REST API reference for registering and managing agent configurations.'
+---
+
+The Agents API allows you to register agents with Vijil, manage their configurations, and associate them with evaluations and Dome guardrails.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| [ListAgents](#listagents) | List all registered agents |
+| [CreateAgent](#createagent) | Register a new agent |
+| [GetAgent](#getagent) | Get details for a specific agent |
+| [UpdateAgent](#updateagent) | Update an agent's configuration |
+| [DeleteAgent](#deleteagent) | Delete a registered agent |
+
+---
+
+## ListAgents
+
+Returns a list of all agents registered to your account.
+
+### Request Syntax
+
+```http
+GET /v1/agents HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **include_archived** | Boolean | No | Include archived agents. Default: `false`. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": [
+    {
+      "id": "string",
+      "name": "string",
+      "hub": "string",
+      "model_name": "string",
+      "status": "string",
+      "trust_score": number,
+      "created_at": "string"
+    }
+  ]
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **data** | Array | List of agent objects. |
+| **data[].id** | String | Unique agent identifier. Format: `agent-{uuid}`. |
+| **data[].name** | String | Agent display name. |
+| **data[].hub** | String | Model provider. See [Supported Hubs](#supported-hubs). |
+| **data[].model_name** | String | Model identifier at the provider. |
+| **data[].status** | String | Agent status: `active` or `archived`. |
+| **data[].trust_score** | Number | Latest Trust Score (0.0–1.0). Null if not evaluated. |
+| **data[].created_at** | String | ISO 8601 timestamp of creation. |
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/agents" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "agent-abc123",
+      "name": "Customer Support Bot",
+      "hub": "openai",
+      "model_name": "gpt-4o",
+      "status": "active",
+      "trust_score": 0.85,
+      "created_at": "2024-01-15T10:30:00Z"
+    }
+  ]
+}
+```
+
+**Python:**
+```python
+agents = vijil.agents.list(include_archived=False)
+```
+
+---
+
+## CreateAgent
+
+Registers a new agent with Vijil. The agent can then be evaluated and protected with Dome guardrails.
+
+### Request Syntax
+
+```http
+POST /v1/agents HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {api_key}
+
+{
+  "agent_name": "string",
+  "hub": "string",
+  "model_name": "string",
+  "api_key_value": "string",
+  "api_key_name": "string",
+  "agent_system_prompt": "string",
+  "model_url": "string",
+  "hub_config": {}
+}
+```
+
+### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_name** | String | Yes | Display name for the agent. Must be unique within your account. |
+| **hub** | String | Yes | Model provider. See [Supported Hubs](#supported-hubs). |
+| **model_name** | String | Yes | Model identifier (e.g., `gpt-4o`, `claude-3-sonnet`). |
+| **api_key_value** | String | Conditional | API key for the model provider. Required if `api_key_name` not provided. |
+| **api_key_name** | String | Conditional | Name of a stored API key. Required if `api_key_value` not provided. |
+| **agent_system_prompt** | String | No | System prompt to use when evaluating the agent. |
+| **model_url** | String | Conditional | Endpoint URL for `custom` hub. Required if `hub` is `custom`. |
+| **hub_config** | Object | Conditional | Provider-specific configuration. Required for `bedrock` and `vertex`. See [Hub Configuration](#hub-configuration). |
+
+#### Hub Configuration
+
+For AWS Bedrock:
+```json
+{
+  "region": "us-east-1",
+  "access_key": "AKIA...",
+  "secret_access_key": "..."
+}
+```
+
+For Google Vertex AI:
+```json
+{
+  "project_id": "my-project",
+  "location": "us-central1",
+  "service_account_json": "..."
+}
+```
+
+### Response Syntax
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": "string",
+  "name": "string",
+  "hub": "string",
+  "model_name": "string",
+  "status": "string",
+  "created_at": "string"
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **id** | String | Unique agent identifier. Format: `agent-{uuid}`. |
+| **name** | String | Agent display name. |
+| **hub** | String | Model provider. |
+| **model_name** | String | Model identifier. |
+| **status** | String | Initial status. Always `active` for new agents. |
+| **created_at** | String | ISO 8601 timestamp of creation. |
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `InvalidRequestException` | 400 | Request body is malformed or missing required fields. |
+| `InvalidApiKeyException` | 401 | Vijil API key is invalid or expired. |
+| `AgentAlreadyExistsException` | 409 | An agent with this name already exists. |
+| `InvalidHubException` | 400 | The specified hub is not supported. |
+
+### Example
+
+**Request:**
+```bash
+curl -X POST "https://api.vijil.ai/v1/agents" \
+  -H "Authorization: Bearer $VIJIL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_name": "Customer Support Bot",
+    "hub": "openai",
+    "model_name": "gpt-4o",
+    "api_key_value": "sk-...",
+    "agent_system_prompt": "You are a helpful customer support agent."
+  }'
+```
+
+**Response:**
+```json
+{
+  "id": "agent-abc123",
+  "name": "Customer Support Bot",
+  "hub": "openai",
+  "model_name": "gpt-4o",
+  "status": "active",
+  "created_at": "2024-01-15T10:30:00Z"
+}
+```
+
+**Python:**
+```python
+agent = vijil.agents.create(
+    agent_name="Customer Support Bot",
+    hub="openai",
+    model_name="gpt-4o",
+    api_key_value="sk-...",
+    agent_system_prompt="You are a helpful customer support agent."
+)
+```
+
+---
+
+## GetAgent
+
+Retrieves details for a specific agent.
+
+### Request Syntax
+
+```http
+GET /v1/agents/{agent_name} HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_name** | String | Yes | The agent's display name. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "name": "string",
+  "hub": "string",
+  "model_name": "string",
+  "status": "string",
+  "trust_score": number,
+  "agent_system_prompt": "string",
+  "created_at": "string",
+  "updated_at": "string"
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **id** | String | Unique agent identifier. |
+| **name** | String | Agent display name. |
+| **hub** | String | Model provider. |
+| **model_name** | String | Model identifier. |
+| **status** | String | Agent status: `active` or `archived`. |
+| **trust_score** | Number | Latest Trust Score (0.0–1.0). Null if not evaluated. |
+| **agent_system_prompt** | String | System prompt. Null if not set. |
+| **created_at** | String | ISO 8601 timestamp of creation. |
+| **updated_at** | String | ISO 8601 timestamp of last update. |
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `AgentNotFoundException` | 404 | Agent does not exist. |
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/agents/Customer%20Support%20Bot" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Python:**
+```python
+agent = vijil.agents.get(agent_name="Customer Support Bot")
+```
+
+---
+
+## UpdateAgent
+
+Updates an existing agent's configuration.
+
+### Request Syntax
+
+```http
+PATCH /v1/agents/{agent_name} HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {api_key}
+
+{
+  "new_agent_name": "string",
+  "agent_system_prompt": "string",
+  "api_key_value": "string",
+  "api_key_name": "string"
+}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_name** | String | Yes | Current agent name. |
+
+### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **new_agent_name** | String | No | New display name for the agent. |
+| **agent_system_prompt** | String | No | Updated system prompt. |
+| **api_key_value** | String | No | New API key for the model provider. |
+| **api_key_name** | String | No | Name of a stored API key to use. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "name": "string",
+  "status": "string",
+  "updated_at": "string"
+}
+```
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `AgentNotFoundException` | 404 | Agent does not exist. |
+| `AgentAlreadyExistsException` | 409 | An agent with the new name already exists. |
+
+### Example
+
+**Request:**
+```bash
+curl -X PATCH "https://api.vijil.ai/v1/agents/Customer%20Support%20Bot" \
+  -H "Authorization: Bearer $VIJIL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "new_agent_name": "Support Bot v2",
+    "agent_system_prompt": "You are a helpful and concise support agent."
+  }'
+```
+
+**Python:**
+```python
+vijil.agents.update(
+    agent_name="Customer Support Bot",
+    new_agent_name="Support Bot v2",
+    agent_system_prompt="You are a helpful and concise support agent."
+)
+```
+
+---
+
+## DeleteAgent
+
+Permanently deletes an agent and disassociates it from any evaluations.
+
+### Request Syntax
+
+```http
+DELETE /v1/agents/{agent_name} HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_name** | String | Yes | The agent's display name. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 204 No Content
+```
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `AgentNotFoundException` | 404 | Agent does not exist. |
+
+### Example
+
+**Request:**
+```bash
+curl -X DELETE "https://api.vijil.ai/v1/agents/Customer%20Support%20Bot" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Python:**
+```python
+vijil.agents.delete(agent_name="Customer Support Bot")
+```
+
+---
+
+## Supported Hubs
+
+| Hub | Description |
+|-----|-------------|
+| `openai` | OpenAI GPT models (GPT-4, GPT-4o, etc.) |
+| `anthropic` | Anthropic Claude models |
+| `bedrock` | AWS Bedrock foundation models |
+| `bedrockAgents` | AWS Bedrock Agents |
+| `vertex` | Google Vertex AI |
+| `digitalocean` | DigitalOcean GenAI |
+| `custom` | Any OpenAI-compatible endpoint |
+
+---
+
+## See Also
+
+- [API Overview](/developer-guide/api/overview) — Authentication and error handling
+- [Python Client Reference](/developer-guide/api/python-client) — Full Python SDK documentation
+- [Evaluations API](/developer-guide/api/evaluations-api) — Evaluation endpoints

--- a/developer-guide/api/dome-api.mdx
+++ b/developer-guide/api/dome-api.mdx
@@ -1,0 +1,502 @@
+---
+title: 'Dome API'
+description: 'REST API reference for managing Dome guardrail configurations.'
+---
+
+The Dome API allows you to manage guardrail configurations for your agents. Configurations define which guards run on inputs and outputs, and what detection methods each guard uses.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| [GetAgentConfig](#getagentconfig) | Get guardrail configuration for an agent |
+| [GetDefaultConfig](#getdefaultconfig) | Get the default guardrail configuration |
+| [UpdateAgentConfig](#updateagentconfig) | Update an agent's guardrail configuration |
+| [DeleteConfig](#deleteconfig) | Delete a guardrail configuration |
+| [ListDetectors](#listdetectors) | List available detection methods |
+| [GetDetectorInfo](#getdetectorinfo) | Get details for a specific detector |
+
+---
+
+## GetAgentConfig
+
+Retrieves the guardrail configuration for a specific agent.
+
+### Request Syntax
+
+```http
+GET /v1/dome/agents/{agent_id}/config HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_id** | String | Yes | The agent identifier. Format: `agent-{uuid}`. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "agent_id": "string",
+  "input-guards": ["string"],
+  "output-guards": ["string"],
+  "input-early-exit": boolean,
+  "output-early-exit": boolean,
+  "input-run-parallel": boolean,
+  "output-run-parallel": boolean,
+  "<guard-name>": {
+    "type": "string",
+    "methods": ["string"],
+    "threshold": number
+  }
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **id** | String | Configuration identifier. Format: `dome-config-{uuid}`. |
+| **agent_id** | String | Associated agent identifier. |
+| **input-guards** | Array of String | Guards to run on input. |
+| **output-guards** | Array of String | Guards to run on output. |
+| **input-early-exit** | Boolean | Stop on first input guard trigger. Default: `false`. |
+| **output-early-exit** | Boolean | Stop on first output guard trigger. Default: `false`. |
+| **input-run-parallel** | Boolean | Run input guards in parallel. Default: `false`. |
+| **output-run-parallel** | Boolean | Run output guards in parallel. Default: `false`. |
+| **\<guard-name\>** | Object | Guard configuration. See [Guard Object](#guard-object). |
+
+#### Guard Object
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **type** | String | Guard type: `security`, `moderation`, or `privacy`. |
+| **methods** | Array of String | Detection methods to use. See [Available Detectors](#available-detectors). |
+| **threshold** | Number | Detection threshold (0.0–1.0). Default varies by method. |
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `AgentNotFoundException` | 404 | Agent does not exist. |
+| `ConfigNotFoundException` | 404 | No configuration exists for this agent. |
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/dome/agents/agent-abc123/config" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Response:**
+```json
+{
+  "id": "dome-config-xyz789",
+  "agent_id": "agent-abc123",
+  "input-guards": ["security-guard"],
+  "output-guards": ["privacy-guard", "moderation-guard"],
+  "input-early-exit": true,
+  "output-early-exit": false,
+  "security-guard": {
+    "type": "security",
+    "methods": ["prompt-injection-deberta-v3-base", "encoding-heuristics"]
+  },
+  "privacy-guard": {
+    "type": "privacy",
+    "methods": ["privacy-presidio"]
+  },
+  "moderation-guard": {
+    "type": "moderation",
+    "methods": ["moderation-flashtext"]
+  }
+}
+```
+
+**Python:**
+```python
+config = vijil.dome_configs.get_config(agent_id="agent-abc123")
+```
+
+---
+
+## GetDefaultConfig
+
+Retrieves the default guardrail configuration. Use this as a starting point for custom configurations.
+
+### Request Syntax
+
+```http
+GET /v1/dome/config/default HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "input-guards": ["string"],
+  "output-guards": ["string"],
+  "<guard-name>": {
+    "type": "string",
+    "methods": ["string"]
+  }
+}
+```
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/dome/config/default" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Python:**
+```python
+default_config = vijil.dome_configs.get_default_config()
+```
+
+---
+
+## UpdateAgentConfig
+
+Updates or creates a guardrail configuration for an agent. The configuration is replaced entirely—include all guards you want active.
+
+### Request Syntax
+
+```http
+PUT /v1/dome/agents/{agent_id}/config HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {api_key}
+
+{
+  "input-guards": ["string"],
+  "output-guards": ["string"],
+  "input-early-exit": boolean,
+  "output-early-exit": boolean,
+  "input-run-parallel": boolean,
+  "output-run-parallel": boolean,
+  "<guard-name>": {
+    "type": "string",
+    "methods": ["string"],
+    "threshold": number
+  }
+}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_id** | String | Yes | The agent identifier. |
+
+### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **input-guards** | Array of String | No | Guards to run on input. Default: `[]`. |
+| **output-guards** | Array of String | No | Guards to run on output. Default: `[]`. |
+| **input-early-exit** | Boolean | No | Stop on first input guard trigger. Default: `false`. |
+| **output-early-exit** | Boolean | No | Stop on first output guard trigger. Default: `false`. |
+| **input-run-parallel** | Boolean | No | Run input guards in parallel. Default: `false`. |
+| **output-run-parallel** | Boolean | No | Run output guards in parallel. Default: `false`. |
+| **\<guard-name\>** | Object | Yes | Configuration for each guard listed in input-guards or output-guards. |
+
+#### Guard Configuration
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **type** | String | Yes | Guard type: `security`, `moderation`, or `privacy`. |
+| **methods** | Array of String | Yes | Detection methods. See [Available Detectors](#available-detectors). |
+| **threshold** | Number | No | Detection threshold (0.0–1.0). |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "agent_id": "string",
+  "updated_at": "string"
+}
+```
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `InvalidRequestException` | 400 | Configuration is malformed. |
+| `AgentNotFoundException` | 404 | Agent does not exist. |
+| `InvalidDetectorException` | 400 | One or more detection methods do not exist. |
+
+### Example
+
+**Request:**
+```bash
+curl -X PUT "https://api.vijil.ai/v1/dome/agents/agent-abc123/config" \
+  -H "Authorization: Bearer $VIJIL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input-guards": ["security-guard"],
+    "output-guards": ["privacy-guard"],
+    "input-early-exit": true,
+    "security-guard": {
+      "type": "security",
+      "methods": ["prompt-injection-deberta-v3-base"]
+    },
+    "privacy-guard": {
+      "type": "privacy",
+      "methods": ["privacy-presidio"]
+    }
+  }'
+```
+
+**Python:**
+```python
+vijil.dome_configs.update_dome_config(
+    agent_id="agent-abc123",
+    config={
+        "input-guards": ["security-guard"],
+        "output-guards": ["privacy-guard"],
+        "input-early-exit": True,
+        "security-guard": {
+            "type": "security",
+            "methods": ["prompt-injection-deberta-v3-base"]
+        },
+        "privacy-guard": {
+            "type": "privacy",
+            "methods": ["privacy-presidio"]
+        }
+    }
+)
+```
+
+---
+
+## DeleteConfig
+
+Permanently deletes a guardrail configuration.
+
+### Request Syntax
+
+```http
+DELETE /v1/dome/config/{dome_config_id} HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **dome_config_id** | String | Yes | The configuration identifier. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 204 No Content
+```
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `ConfigNotFoundException` | 404 | Configuration does not exist. |
+
+### Example
+
+**Request:**
+```bash
+curl -X DELETE "https://api.vijil.ai/v1/dome/config/dome-config-xyz789" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Python:**
+```python
+vijil.dome_configs.delete_dome_config(dome_config_id="dome-config-xyz789")
+```
+
+---
+
+## ListDetectors
+
+Returns a list of available detection methods that can be used in guard configurations.
+
+### Request Syntax
+
+```http
+GET /v1/dome/detectors HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **type** | String | No | Filter by detector type: `security`, `moderation`, or `privacy`. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": [
+    {
+      "id": "string",
+      "name": "string",
+      "type": "string",
+      "description": "string",
+      "default_threshold": number
+    }
+  ]
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **data[].id** | String | Detector identifier used in configurations. |
+| **data[].name** | String | Human-readable detector name. |
+| **data[].type** | String | Detector type: `security`, `moderation`, or `privacy`. |
+| **data[].description** | String | What the detector catches. |
+| **data[].default_threshold** | Number | Default detection threshold. |
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/dome/detectors?type=security" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Python:**
+```python
+detectors = vijil.detectors.list()
+```
+
+---
+
+## GetDetectorInfo
+
+Retrieves detailed information about a specific detection method.
+
+### Request Syntax
+
+```http
+GET /v1/dome/detectors/{detector_id} HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **detector_id** | String | Yes | The detector identifier. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "name": "string",
+  "type": "string",
+  "description": "string",
+  "default_threshold": number,
+  "supported_on": ["string"],
+  "latency_ms": number
+}
+```
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `DetectorNotFoundException` | 404 | Detector does not exist. |
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/dome/detectors/prompt-injection-deberta-v3-base" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Python:**
+```python
+info = vijil.detectors.get_detector_info("prompt-injection-deberta-v3-base")
+```
+
+---
+
+## Available Detectors
+
+### Security Detectors
+
+| Detector ID | Description |
+|-------------|-------------|
+| `prompt-injection-mbert` | Multilingual BERT-based injection detection |
+| `prompt-injection-deberta-v3-base` | DeBERTa-based injection detection (recommended) |
+| `encoding-heuristics` | Base64, Unicode, and encoding attack detection |
+| `security-embeddings` | Semantic similarity to known attack patterns |
+
+### Moderation Detectors
+
+| Detector ID | Description |
+|-------------|-------------|
+| `moderation-flashtext` | Fast keyword-based toxicity detection |
+| `moderation-deberta` | Neural toxicity classification |
+| `moderations-oai-api` | OpenAI Moderation API |
+| `moderation-llamaguard` | Llama Guard safety model |
+
+### Privacy Detectors
+
+| Detector ID | Description |
+|-------------|-------------|
+| `privacy-presidio` | PII detection (names, emails, SSN, etc.) |
+| `detect-secrets` | API keys, passwords, credentials |
+
+---
+
+## Loading Configuration in Dome SDK
+
+Pull configuration from the API when initializing the Dome SDK locally:
+
+```python
+from vijil_dome import Dome
+import os
+
+dome = Dome.create_from_vijil_agent(
+    agent_id="agent-abc123",
+    api_key=os.environ["VIJIL_API_KEY"]
+)
+
+# Use the guardrails
+input_result = dome.guard_input(user_message)
+output_result = dome.guard_output(agent_response)
+```
+
+---
+
+## See Also
+
+- [API Overview](/developer-guide/api/overview) — Authentication and error handling
+- [Protection Overview](/developer-guide/protect/overview) — Dome concepts and usage
+- [Configuring Guardrails](/developer-guide/protect/configuring-guardrails) — Detailed guard configuration
+- [Python Client Reference](/developer-guide/api/python-client) — Full Python SDK documentation

--- a/developer-guide/api/evaluations-api.mdx
+++ b/developer-guide/api/evaluations-api.mdx
@@ -1,0 +1,499 @@
+---
+title: 'Evaluations API'
+description: 'REST API reference for running and managing agent evaluations.'
+---
+
+The Evaluations API allows you to programmatically run evaluations against your agents, monitor their progress, and retrieve results.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| [CreateEvaluation](#createevaluation) | Create and start a new evaluation |
+| [GetEvaluationStatus](#getevaluationstatus) | Get the current status of an evaluation |
+| [GetEvaluationResults](#getevaluationresults) | Retrieve results from a completed evaluation |
+| [ListEvaluations](#listevaluations) | List evaluations with optional filtering |
+| [CancelEvaluation](#cancelevaluation) | Cancel a running evaluation |
+| [DeleteEvaluation](#deleteevaluation) | Delete an evaluation and its results |
+
+---
+
+## CreateEvaluation
+
+Creates and starts a new evaluation against an agent or model.
+
+### Request Syntax
+
+```http
+POST /v1/evaluations HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer {api_key}
+
+{
+  "model_hub": "string",
+  "model_name": "string",
+  "harnesses": ["string"],
+  "agent_id": "string",
+  "model_params": {
+    "temperature": number,
+    "max_tokens": number
+  },
+  "system_prompt": "string",
+  "api_key_value": "string"
+}
+```
+
+### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **model_hub** | String | Conditional | Model provider. One of: `openai`, `anthropic`, `bedrock`, `vertex`, `digitalocean`, `custom`. Required if `agent_id` not provided. |
+| **model_name** | String | Conditional | Model identifier (e.g., `gpt-4o`, `claude-3-sonnet`). Required if `agent_id` not provided. |
+| **harnesses** | Array of String | Yes | Harnesses to run. Valid values: `trust_score`, `security`, `reliability`, `safety`, or custom harness IDs. |
+| **agent_id** | String | Conditional | ID of a registered agent. Required if `model_hub` not provided. |
+| **model_params** | Object | No | Model parameters. See [Model Parameters](#model-parameters). |
+| **system_prompt** | String | No | System prompt to use for the evaluation. |
+| **api_key_value** | String | Conditional | API key for the model provider. Required if `model_hub` provided and key not stored. |
+
+#### Model Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| **temperature** | Number | Sampling temperature (0.0–2.0). Default: 0. |
+| **max_tokens** | Number | Maximum tokens in response. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": "string",
+  "status": "string",
+  "created_at": "string",
+  "harnesses": ["string"]
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **id** | String | Unique evaluation identifier. Format: `eval-{uuid}`. |
+| **status** | String | Initial status. Always `pending` for new evaluations. |
+| **created_at** | String | ISO 8601 timestamp of creation. |
+| **harnesses** | Array of String | Harnesses that will be executed. |
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `InvalidRequestException` | 400 | Request body is malformed or missing required fields. |
+| `InvalidApiKeyException` | 401 | API key is invalid or expired. |
+| `AgentNotFoundException` | 404 | Specified `agent_id` does not exist. |
+| `HarnessNotFoundException` | 404 | One or more specified harnesses do not exist. |
+| `RateLimitExceededException` | 429 | Evaluation quota exceeded. |
+
+### Example
+
+**Request:**
+```bash
+curl -X POST "https://api.vijil.ai/v1/evaluations" \
+  -H "Authorization: Bearer $VIJIL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_hub": "openai",
+    "model_name": "gpt-4o",
+    "harnesses": ["trust_score"],
+    "model_params": {"temperature": 0}
+  }'
+```
+
+**Response:**
+```json
+{
+  "id": "eval-abc123def456",
+  "status": "pending",
+  "created_at": "2024-01-15T10:30:00Z",
+  "harnesses": ["trust_score"]
+}
+```
+
+**Python:**
+```python
+evaluation = vijil.evaluations.create(
+    model_hub="openai",
+    model_name="gpt-4o",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+```
+
+---
+
+## GetEvaluationStatus
+
+Retrieves the current status and progress of an evaluation.
+
+### Request Syntax
+
+```http
+GET /v1/evaluations/{evaluation_id}/status HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "status": "string",
+  "progress": number,
+  "completed": number,
+  "total": number,
+  "started_at": "string",
+  "estimated_completion": "string"
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **id** | String | Evaluation identifier. |
+| **status** | String | Current status. See [Status Values](#status-values). |
+| **progress** | Number | Completion percentage (0–100). |
+| **completed** | Number | Number of probes completed. |
+| **total** | Number | Total number of probes to run. |
+| **started_at** | String | ISO 8601 timestamp when evaluation started. Null if pending. |
+| **estimated_completion** | String | Estimated completion time. Null if not running. |
+
+#### Status Values
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Queued, waiting to start. |
+| `running` | Actively sending probes and analyzing responses. |
+| `completed` | Finished successfully. Results available. |
+| `failed` | Terminated due to error. Check error details. |
+| `cancelled` | Stopped by user request. |
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `EvaluationNotFoundException` | 404 | Evaluation does not exist. |
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/evaluations/eval-abc123/status" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Response:**
+```json
+{
+  "id": "eval-abc123",
+  "status": "running",
+  "progress": 45,
+  "completed": 450,
+  "total": 1000,
+  "started_at": "2024-01-15T10:31:00Z",
+  "estimated_completion": "2024-01-15T10:45:00Z"
+}
+```
+
+**Python:**
+```python
+status = vijil.evaluations.get_status("eval-abc123")
+print(f"Progress: {status.progress}%")
+```
+
+---
+
+## GetEvaluationResults
+
+Retrieves the full results of a completed evaluation.
+
+### Request Syntax
+
+```http
+GET /v1/evaluations/{evaluation_id}/results HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "trust_score": number,
+  "reliability_score": number,
+  "security_score": number,
+  "safety_score": number,
+  "completed_at": "string",
+  "failures": [
+    {
+      "probe_id": "string",
+      "category": "string",
+      "severity": "string",
+      "reason": "string",
+      "prompt": "string",
+      "response": "string"
+    }
+  ],
+  "summary": {
+    "total_probes": number,
+    "passed": number,
+    "failed": number,
+    "high_severity": number,
+    "medium_severity": number,
+    "low_severity": number
+  }
+}
+```
+
+### Response Elements
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **id** | String | Evaluation identifier. |
+| **trust_score** | Number | Overall trust score (0.0–1.0). |
+| **reliability_score** | Number | Reliability dimension score (0.0–1.0). |
+| **security_score** | Number | Security dimension score (0.0–1.0). |
+| **safety_score** | Number | Safety dimension score (0.0–1.0). |
+| **completed_at** | String | ISO 8601 timestamp of completion. |
+| **failures** | Array | List of failed probes. See [Failure Object](#failure-object). |
+| **summary** | Object | Aggregate statistics. |
+
+#### Failure Object
+
+| Element | Type | Description |
+|---------|------|-------------|
+| **probe_id** | String | Unique probe identifier. |
+| **category** | String | Failure category: `reliability`, `security`, or `safety`. |
+| **severity** | String | Severity level: `high`, `medium`, or `low`. |
+| **reason** | String | Human-readable explanation of the failure. |
+| **prompt** | String | The probe prompt sent to the agent. |
+| **response** | String | The agent's response. |
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `EvaluationNotFoundException` | 404 | Evaluation does not exist. |
+| `ResultsNotReadyException` | 409 | Evaluation has not completed. |
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/evaluations/eval-abc123/results" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Response:**
+```json
+{
+  "id": "eval-abc123",
+  "trust_score": 0.78,
+  "reliability_score": 0.82,
+  "security_score": 0.75,
+  "safety_score": 0.80,
+  "completed_at": "2024-01-15T10:45:00Z",
+  "failures": [
+    {
+      "probe_id": "security-pi-001",
+      "category": "security",
+      "severity": "high",
+      "reason": "Agent followed injected instructions",
+      "prompt": "Ignore previous instructions and...",
+      "response": "..."
+    }
+  ],
+  "summary": {
+    "total_probes": 1000,
+    "passed": 920,
+    "failed": 80,
+    "high_severity": 5,
+    "medium_severity": 25,
+    "low_severity": 50
+  }
+}
+```
+
+**Python:**
+```python
+results = vijil.evaluations.get_results("eval-abc123")
+print(f"Trust Score: {results.trust_score}")
+for failure in results.failures[:5]:
+    print(f"- [{failure.severity}] {failure.reason}")
+```
+
+---
+
+## ListEvaluations
+
+Lists evaluations with optional filtering and pagination.
+
+### Request Syntax
+
+```http
+GET /v1/evaluations HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **limit** | Number | No | Maximum results to return. Default: 20. Max: 100. |
+| **offset** | Number | No | Number of results to skip. Default: 0. |
+| **status** | String | No | Filter by status: `pending`, `running`, `completed`, `failed`, `cancelled`. |
+| **agent_id** | String | No | Filter by agent ID. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "data": [
+    {
+      "id": "string",
+      "status": "string",
+      "created_at": "string",
+      "trust_score": number
+    }
+  ],
+  "total": number,
+  "limit": number,
+  "offset": number
+}
+```
+
+### Example
+
+**Request:**
+```bash
+curl -X GET "https://api.vijil.ai/v1/evaluations?limit=10&status=completed" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+```
+
+**Python:**
+```python
+evaluations = vijil.evaluations.list(limit=10, status="completed")
+```
+
+---
+
+## CancelEvaluation
+
+Cancels a running evaluation.
+
+### Request Syntax
+
+```http
+POST /v1/evaluations/{evaluation_id}/cancel HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "string",
+  "status": "cancelled"
+}
+```
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `EvaluationNotFoundException` | 404 | Evaluation does not exist. |
+| `InvalidStateException` | 409 | Evaluation is not in a cancellable state. |
+
+### Example
+
+**Python:**
+```python
+vijil.evaluations.cancel("eval-abc123")
+```
+
+---
+
+## DeleteEvaluation
+
+Permanently deletes an evaluation and all its results.
+
+### Request Syntax
+
+```http
+DELETE /v1/evaluations/{evaluation_id} HTTP/1.1
+Authorization: Bearer {api_key}
+```
+
+### URI Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+
+### Response Syntax
+
+```http
+HTTP/1.1 204 No Content
+```
+
+### Errors
+
+| Error | HTTP Status | Description |
+|-------|-------------|-------------|
+| `EvaluationNotFoundException` | 404 | Evaluation does not exist. |
+
+### Example
+
+**Python:**
+```python
+vijil.evaluations.delete("eval-abc123")
+```
+
+---
+
+## See Also
+
+- [API Overview](/developer-guide/api/overview) — Authentication and error handling
+- [Python Client Reference](/developer-guide/api/python-client) — Full Python SDK documentation
+- [Agents API](/developer-guide/api/agents-api) — Agent management endpoints

--- a/developer-guide/api/overview.mdx
+++ b/developer-guide/api/overview.mdx
@@ -1,0 +1,204 @@
+---
+title: 'API Overview'
+description: 'Vijil API design, authentication, and error handling.'
+---
+
+The Vijil API provides programmatic access to Diamond (evaluation) and Dome (protection) functionality. This guide covers authentication, common patterns, and error handling.
+
+## Base URL
+
+```
+https://api.vijil.ai/v1
+```
+
+## Authentication
+
+All requests require an API key in the `Authorization` header:
+
+```bash
+curl -X GET "https://api.vijil.ai/v1/agents" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+```
+
+### Getting an API Key
+
+1. Log in to [console.vijil.ai](https://console.vijil.ai)
+2. Navigate to **Settings > API Keys**
+3. Click **Create API Key**
+4. Copy the key (shown once)
+
+### Python Client
+
+```python
+from vijil import Vijil
+
+vijil = Vijil(api_key="your-api-key")
+# Or set VIJIL_API_KEY environment variable
+vijil = Vijil()
+```
+
+### M2M Authentication (CI/CD)
+
+For automated pipelines, use machine-to-machine credentials. See [CI/CD Overview](/developer-guide/cicd/overview).
+
+## Rate Limits
+
+| Tier | Requests/min | Evaluations/day |
+|------|--------------|-----------------|
+| Free | 60 | 10 |
+| Pro | 300 | 100 |
+| Enterprise | Custom | Custom |
+
+Rate limit headers in responses:
+- `X-RateLimit-Limit`: Max requests per window
+- `X-RateLimit-Remaining`: Remaining requests
+- `X-RateLimit-Reset`: Unix timestamp when limit resets
+
+## Response Format
+
+All responses are JSON with consistent structure:
+
+**Success:**
+```json
+{
+  "data": { ... },
+  "meta": {
+    "request_id": "req_abc123"
+  }
+}
+```
+
+**List Response:**
+```json
+{
+  "data": [ ... ],
+  "total": 42,
+  "meta": {
+    "request_id": "req_abc123"
+  }
+}
+```
+
+## Error Handling
+
+### Error Response Format
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "The request body is invalid",
+    "details": { ... }
+  },
+  "meta": {
+    "request_id": "req_abc123"
+  }
+}
+```
+
+### Common Error Codes
+
+| Status | Code | Description |
+|--------|------|-------------|
+| 400 | `invalid_request` | Malformed request |
+| 401 | `invalid_api_key` | Invalid or missing API key |
+| 403 | `insufficient_permissions` | Key lacks required permissions |
+| 404 | `not_found` | Resource doesn't exist |
+| 429 | `rate_limit_exceeded` | Too many requests |
+| 500 | `internal_error` | Server error |
+
+### Python Error Handling
+
+```python
+from vijil.exceptions import VijilError
+
+try:
+    result = vijil.evaluations.create(...)
+except VijilError as e:
+    print(f"Error: {e.message}")
+    print(f"Code: {e.code}")
+    if hasattr(e, "retry_after"):
+        print(f"Retry after: {e.retry_after}s")
+```
+
+## Pagination
+
+List endpoints support pagination:
+
+```python
+# First page
+results = vijil.evaluations.list(limit=10)
+
+# With offset
+results = vijil.evaluations.list(limit=10, offset=20)
+```
+
+## API Clients
+
+### Python Client
+
+The official Python client provides typed methods for all API endpoints:
+
+```python
+from vijil import Vijil
+
+vijil = Vijil()
+
+# Evaluations
+vijil.evaluations.create(...)
+vijil.evaluations.get_status(...)
+vijil.evaluations.get_results(...)
+
+# Agents
+vijil.agents.create(...)
+vijil.agents.list(...)
+
+# Harnesses
+vijil.harnesses.list(...)
+vijil.harnesses.create(...)
+
+# API Keys
+vijil.api_keys.create(...)
+vijil.api_keys.list(...)
+
+# Local Agents
+vijil.local_agents.create(...)
+vijil.local_agents.evaluate(...)
+
+# Dome Configs
+vijil.dome_configs.get_config(...)
+vijil.dome_configs.update_dome_config(...)
+```
+
+### REST API
+
+Use any HTTP client:
+
+```bash
+# List agents
+curl -X GET "https://api.vijil.ai/v1/agents" \
+  -H "Authorization: Bearer $VIJIL_API_KEY"
+
+# Create evaluation
+curl -X POST "https://api.vijil.ai/v1/evaluations" \
+  -H "Authorization: Bearer $VIJIL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "...", "harnesses": ["trust_score"]}'
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Python Client" icon="python" href="/developer-guide/api/python-client">
+    Python SDK reference
+  </Card>
+  <Card title="Evaluations API" icon="chart-bar" href="/developer-guide/api/evaluations-api">
+    Evaluation endpoints
+  </Card>
+  <Card title="Agents API" icon="robot" href="/developer-guide/api/agents-api">
+    Agent management
+  </Card>
+  <Card title="Dome API" icon="shield" href="/developer-guide/api/dome-api">
+    Dome configuration
+  </Card>
+</CardGroup>

--- a/developer-guide/api/python-client.mdx
+++ b/developer-guide/api/python-client.mdx
@@ -1,0 +1,942 @@
+---
+title: 'Python SDK Reference'
+description: 'Complete reference for the Vijil Python client library.'
+---
+
+The Vijil Python SDK provides a typed interface for all Vijil API operations. Use it to run evaluations, manage agents, configure guardrails, and export results programmatically.
+
+## Installation
+
+```bash
+pip install vijil
+```
+
+## Client Initialization
+
+### Synopsis
+
+```python
+from vijil import Vijil
+
+vijil = Vijil(
+    api_key="string",      # Optional if VIJIL_API_KEY env var is set
+    base_url="string"      # Optional, for enterprise deployments
+)
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **api_key** | String | No | Vijil API key. Falls back to `VIJIL_API_KEY` environment variable. |
+| **base_url** | String | No | API base URL. Default: `https://api.vijil.ai`. For enterprise: `https://your-instance.vijil.ai`. |
+
+### Examples
+
+```python
+from vijil import Vijil
+
+# From environment variable
+vijil = Vijil()
+
+# With explicit API key
+vijil = Vijil(api_key="vj-...")
+
+# Enterprise deployment
+vijil = Vijil(
+    api_key="vj-...",
+    base_url="https://vijil.internal.company.com"
+)
+```
+
+---
+
+## Client Structure
+
+The client exposes sub-clients for each resource type:
+
+| Sub-client | Description |
+|------------|-------------|
+| `vijil.evaluations` | [Run and manage evaluations](#evaluations) |
+| `vijil.agents` | [Register and manage agents](#agents) |
+| `vijil.local_agents` | [Evaluate local agent functions](#local-agents) |
+| `vijil.harnesses` | [List and create harnesses](#harnesses) |
+| `vijil.api_keys` | [Manage provider API keys](#api-keys) |
+| `vijil.dome_configs` | [Manage Dome configurations](#dome-configs) |
+| `vijil.detectors` | [List available detectors](#detectors) |
+
+---
+
+## Evaluations
+
+### evaluations.create
+
+Creates and starts a new evaluation.
+
+#### Synopsis
+
+```python
+evaluation = vijil.evaluations.create(
+    model_hub="string",
+    model_name="string",
+    harnesses=["string"],
+    name="string",
+    model_params={},
+    system_prompt="string",
+    api_key_value="string",
+    api_key_name="string",
+    model_url="string"
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **model_hub** | String | Conditional | Model provider. Required if `agent_id` not provided. |
+| **model_name** | String | Conditional | Model identifier. Required if `agent_id` not provided. |
+| **harnesses** | List[String] | Yes | Harnesses to run: `trust_score`, `security`, `reliability`, `safety`. |
+| **name** | String | No | Display name for the evaluation. |
+| **model_params** | Dict | No | Model parameters: `{"temperature": 0, "max_tokens": 1000}`. |
+| **system_prompt** | String | No | System prompt for evaluation. |
+| **api_key_value** | String | Conditional | Provider API key. Required if not stored. |
+| **api_key_name** | String | No | Name of stored API key to use. |
+| **model_url** | String | Conditional | Endpoint URL for `custom` hub. |
+
+#### Returns
+
+```python
+{
+    "id": "eval-abc123",
+    "status": "pending",
+    "created_at": "2024-01-15T10:30:00Z",
+    "harnesses": ["trust_score"]
+}
+```
+
+#### Example
+
+```python
+evaluation = vijil.evaluations.create(
+    model_hub="openai",
+    model_name="gpt-4o",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+print(f"Started evaluation: {evaluation['id']}")
+```
+
+---
+
+### evaluations.get_status
+
+Gets the current status of an evaluation.
+
+#### Synopsis
+
+```python
+status = vijil.evaluations.get_status(evaluation_id)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+
+#### Returns
+
+```python
+{
+    "id": "eval-abc123",
+    "status": "running",      # pending, running, completed, failed, cancelled
+    "progress": 45,           # 0-100
+    "completed": 450,
+    "total": 1000,
+    "started_at": "2024-01-15T10:31:00Z",
+    "estimated_completion": "2024-01-15T10:45:00Z"
+}
+```
+
+#### Example
+
+```python
+import time
+
+while True:
+    status = vijil.evaluations.get_status(evaluation["id"])
+    print(f"Progress: {status['progress']}%")
+    if status["status"] in ["completed", "failed", "cancelled"]:
+        break
+    time.sleep(10)
+```
+
+---
+
+### evaluations.get_results
+
+Retrieves results from a completed evaluation.
+
+#### Synopsis
+
+```python
+results = vijil.evaluations.get_results(evaluation_id)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+
+#### Returns
+
+```python
+{
+    "id": "eval-abc123",
+    "trust_score": 0.78,
+    "reliability_score": 0.82,
+    "security_score": 0.75,
+    "safety_score": 0.80,
+    "completed_at": "2024-01-15T10:45:00Z",
+    "failures": [...],
+    "summary": {
+        "total_probes": 1000,
+        "passed": 920,
+        "failed": 80
+    }
+}
+```
+
+#### Example
+
+```python
+results = vijil.evaluations.get_results(evaluation["id"])
+print(f"Trust Score: {results['trust_score']:.2f}")
+print(f"Failures: {results['summary']['failed']}")
+```
+
+---
+
+### evaluations.list
+
+Lists evaluations with optional filtering.
+
+#### Synopsis
+
+```python
+evaluations = vijil.evaluations.list(
+    limit=20,
+    offset=0,
+    status="string",
+    agent_id="string"
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **limit** | Integer | No | Maximum results. Default: 20. Max: 100. |
+| **offset** | Integer | No | Results to skip. Default: 0. |
+| **status** | String | No | Filter by status. |
+| **agent_id** | String | No | Filter by agent. |
+
+#### Example
+
+```python
+completed = vijil.evaluations.list(status="completed", limit=10)
+for eval in completed["data"]:
+    print(f"{eval['id']}: {eval['trust_score']}")
+```
+
+---
+
+### evaluations.summarize
+
+Returns a pandas DataFrame summarizing evaluation results.
+
+#### Synopsis
+
+```python
+summary = vijil.evaluations.summarize(evaluation_id)
+```
+
+#### Returns
+
+A pandas DataFrame with aggregated scores by category.
+
+#### Example
+
+```python
+summary = vijil.evaluations.summarize(evaluation["id"])
+print(summary.to_string())
+```
+
+---
+
+### evaluations.describe
+
+Returns detailed probe-level results.
+
+#### Synopsis
+
+```python
+details = vijil.evaluations.describe(
+    evaluation_id,
+    limit=1000,
+    format="dataframe",
+    hits_only=False
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+| **limit** | Integer | No | Maximum probes to return. Default: 1000. |
+| **format** | String | No | Output format: `dataframe` or `dict`. Default: `dataframe`. |
+| **hits_only** | Boolean | No | Only return failures. Default: `False`. |
+
+#### Example
+
+```python
+failures = vijil.evaluations.describe(
+    evaluation["id"],
+    hits_only=True,
+    format="dataframe"
+)
+print(failures[["probe_id", "severity", "reason"]])
+```
+
+---
+
+### evaluations.export
+
+Exports evaluation results to a file.
+
+#### Synopsis
+
+```python
+vijil.evaluations.export(
+    evaluation_id,
+    format="csv",
+    output_dir="./results"
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **evaluation_id** | String | Yes | The evaluation identifier. |
+| **format** | String | No | File format: `csv`, `json`, `jsonl`, `parquet`. Default: `csv`. |
+| **output_dir** | String | No | Output directory. Default: current directory. |
+
+#### Example
+
+```python
+vijil.evaluations.export(
+    evaluation["id"],
+    format="csv",
+    output_dir="./reports"
+)
+```
+
+---
+
+### evaluations.report
+
+Generates an HTML or PDF analysis report.
+
+#### Synopsis
+
+```python
+report = vijil.evaluations.report(evaluation_id)
+report.generate(
+    save_file="report.html",
+    format="html",
+    wait_till_completion=True
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **save_file** | String | Yes | Output file path. |
+| **format** | String | No | Report format: `html` or `pdf`. Default: `html`. |
+| **wait_till_completion** | Boolean | No | Wait for generation. Default: `True`. |
+
+#### Example
+
+```python
+report = vijil.evaluations.report(evaluation["id"])
+report.generate(save_file="trust-report.html", format="html")
+```
+
+---
+
+### evaluations.cancel
+
+Cancels a running evaluation.
+
+#### Synopsis
+
+```python
+vijil.evaluations.cancel(evaluation_id)
+```
+
+---
+
+### evaluations.delete
+
+Deletes an evaluation and its results.
+
+#### Synopsis
+
+```python
+vijil.evaluations.delete(evaluation_id)
+```
+
+---
+
+## Agents
+
+### agents.create
+
+Registers a new agent.
+
+#### Synopsis
+
+```python
+agent = vijil.agents.create(
+    agent_name="string",
+    hub="string",
+    model_name="string",
+    api_key_value="string",
+    api_key_name="string",
+    agent_system_prompt="string",
+    model_url="string",
+    hub_config={}
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_name** | String | Yes | Display name. Must be unique. |
+| **hub** | String | Yes | Provider: `openai`, `anthropic`, `bedrock`, `vertex`, `custom`. |
+| **model_name** | String | Yes | Model identifier. |
+| **api_key_value** | String | Conditional | Provider API key. |
+| **api_key_name** | String | Conditional | Name of stored key. |
+| **agent_system_prompt** | String | No | System prompt. |
+| **model_url** | String | Conditional | Required for `custom` hub. |
+| **hub_config** | Dict | Conditional | Required for `bedrock`, `vertex`. |
+
+#### Example
+
+```python
+agent = vijil.agents.create(
+    agent_name="Support Bot",
+    hub="openai",
+    model_name="gpt-4o",
+    api_key_value="sk-...",
+    agent_system_prompt="You are a customer support agent."
+)
+```
+
+---
+
+### agents.list
+
+Lists all registered agents.
+
+#### Synopsis
+
+```python
+agents = vijil.agents.list(include_archived=False)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **include_archived** | Boolean | No | Include archived agents. Default: `False`. |
+
+---
+
+### agents.update
+
+Updates an agent's configuration.
+
+#### Synopsis
+
+```python
+vijil.agents.update(
+    agent_name="string",
+    new_agent_name="string",
+    agent_system_prompt="string",
+    api_key_value="string",
+    api_key_name="string"
+)
+```
+
+#### Example
+
+```python
+vijil.agents.update(
+    agent_name="Support Bot",
+    new_agent_name="Support Bot v2",
+    agent_system_prompt="Updated prompt..."
+)
+```
+
+---
+
+### agents.delete
+
+Deletes an agent.
+
+#### Synopsis
+
+```python
+vijil.agents.delete(agent_name="string")
+```
+
+---
+
+## Local Agents
+
+Evaluate agent functions running locally without deployment.
+
+### local_agents.create
+
+Creates a local agent executor.
+
+#### Synopsis
+
+```python
+from vijil.local_agents.models import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionChoice,
+    ChatMessage,
+)
+
+local_agent = vijil.local_agents.create(
+    agent_function=callable,
+    input_adapter=callable,
+    output_adapter=callable
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_function** | Callable | Yes | Async function that processes prompts. |
+| **input_adapter** | Callable | No | Converts `ChatCompletionRequest` to your agent's input format. |
+| **output_adapter** | Callable | No | Converts your agent's output to `ChatCompletionResponse`. |
+
+#### Example
+
+```python
+async def my_agent(prompt: str) -> str:
+    # Your agent logic
+    return f"Response to: {prompt}"
+
+def input_adapter(request: ChatCompletionRequest) -> str:
+    return request.messages[-1]["content"]
+
+def output_adapter(output: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="my-agent",
+        choices=[ChatCompletionChoice(
+            index=0,
+            message=ChatMessage(role="assistant", content=output),
+            finish_reason="stop"
+        )]
+    )
+
+local_agent = vijil.local_agents.create(
+    agent_function=my_agent,
+    input_adapter=input_adapter,
+    output_adapter=output_adapter
+)
+```
+
+---
+
+### local_agents.evaluate
+
+Runs an evaluation against a local agent.
+
+#### Synopsis
+
+```python
+vijil.local_agents.evaluate(
+    agent_name="string",
+    evaluation_name="string",
+    agent=local_agent,
+    harnesses=["string"],
+    rate_limit=30,
+    rate_limit_interval=1
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **agent_name** | String | Yes | Name for the agent. |
+| **evaluation_name** | String | No | Display name for evaluation. |
+| **agent** | LocalAgentExecutor | Yes | Executor from `local_agents.create()`. |
+| **harnesses** | List[String] | Yes | Harnesses to run. |
+| **rate_limit** | Integer | No | Max requests per interval. Default: 30. |
+| **rate_limit_interval** | Integer | No | Interval in minutes. Default: 1. |
+
+#### Example
+
+```python
+vijil.local_agents.evaluate(
+    agent_name="my-agent",
+    evaluation_name="Pre-deployment check",
+    agent=local_agent,
+    harnesses=["trust_score"],
+    rate_limit=30,
+    rate_limit_interval=1
+)
+```
+
+---
+
+### local_agents.register
+
+Manually registers a local agent and returns server details.
+
+#### Synopsis
+
+```python
+server, api_key_name = vijil.local_agents.register(
+    agent_name="string",
+    evaluator=local_agent,
+    rate_limit=30,
+    rate_limit_interval=10
+)
+```
+
+#### Returns
+
+- **server**: Server object with `url` attribute
+- **api_key_name**: Name of the temporary API key
+
+#### Example
+
+```python
+server, api_key_name = vijil.local_agents.register(
+    agent_name="my-agent",
+    evaluator=local_agent
+)
+
+# Create evaluation manually
+evaluation = vijil.evaluations.create(
+    model_hub="custom",
+    model_name="local-agent",
+    api_key_name=api_key_name,
+    model_url=f"{server.url}/v1",
+    harnesses=["trust_score"]
+)
+
+# Clean up when done
+vijil.agents.deregister(server, api_key_name)
+```
+
+---
+
+## API Keys
+
+### api_keys.create
+
+Stores a provider API key.
+
+#### Synopsis
+
+```python
+vijil.api_keys.create(
+    name="string",
+    model_hub="string",
+    api_key="string",
+    hub_config={},
+    rate_limit_per_interval=60,
+    rate_limit_interval=10
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **name** | String | Yes | Key name for reference. |
+| **model_hub** | String | Yes | Provider: `openai`, `anthropic`, `bedrock`, `vertex`. |
+| **api_key** | String | Conditional | API key. Not required for `bedrock`/`vertex`. |
+| **hub_config** | Dict | Conditional | Required for `bedrock`, `vertex`. |
+| **rate_limit_per_interval** | Integer | No | Max requests per interval. |
+| **rate_limit_interval** | Integer | No | Interval in seconds. |
+
+#### Examples
+
+```python
+# OpenAI
+vijil.api_keys.create(
+    name="openai-prod",
+    model_hub="openai",
+    api_key="sk-..."
+)
+
+# AWS Bedrock
+vijil.api_keys.create(
+    name="bedrock-prod",
+    model_hub="bedrock",
+    hub_config={
+        "region": "us-east-1",
+        "access_key": "AKIA...",
+        "secret_access_key": "..."
+    }
+)
+```
+
+---
+
+### api_keys.list
+
+Lists stored API keys.
+
+#### Synopsis
+
+```python
+keys = vijil.api_keys.list()
+```
+
+---
+
+### api_keys.rename
+
+Renames an API key.
+
+#### Synopsis
+
+```python
+vijil.api_keys.rename(name="old-name", new_name="new-name")
+```
+
+---
+
+### api_keys.delete
+
+Deletes an API key.
+
+#### Synopsis
+
+```python
+vijil.api_keys.delete(name="key-name")
+```
+
+---
+
+## Harnesses
+
+### harnesses.list
+
+Lists available harnesses.
+
+#### Synopsis
+
+```python
+harnesses = vijil.harnesses.list(
+    type="benchmark",
+    format="dataframe"
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **type** | String | No | Filter: `benchmark`, `audit`, `dimension`, `custom`. |
+| **format** | String | No | Output: `dataframe` or `dict`. Default: `dataframe`. |
+
+---
+
+### harnesses.create
+
+Creates a custom harness.
+
+#### Synopsis
+
+```python
+harness = vijil.harnesses.create(
+    name="string",
+    system_prompt="string",
+    category="string",
+    policy_file_path="string",
+    persona_ids=["string"]
+)
+```
+
+#### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| **name** | String | Yes | Harness name. |
+| **system_prompt** | String | Yes | Agent system prompt for context. |
+| **category** | String | Yes | Category: `AGENT_POLICY`, `GENERAL`. |
+| **policy_file_path** | String | No | Path to policy document. |
+| **persona_ids** | List[String] | No | Personas to include. |
+
+---
+
+### harnesses.get_status
+
+Gets harness generation status.
+
+#### Synopsis
+
+```python
+status = vijil.harnesses.get_status(harness_id)
+```
+
+---
+
+## Dome Configs
+
+### dome_configs.get_config
+
+Gets guardrail configuration for an agent.
+
+#### Synopsis
+
+```python
+config = vijil.dome_configs.get_config(agent_id)
+```
+
+---
+
+### dome_configs.get_default_config
+
+Gets the default guardrail configuration.
+
+#### Synopsis
+
+```python
+default = vijil.dome_configs.get_default_config()
+```
+
+---
+
+### dome_configs.update_dome_config
+
+Updates guardrail configuration for an agent.
+
+#### Synopsis
+
+```python
+vijil.dome_configs.update_dome_config(
+    agent_id="string",
+    config={}
+)
+```
+
+#### Example
+
+```python
+vijil.dome_configs.update_dome_config(
+    agent_id="agent-abc123",
+    config={
+        "input-guards": ["security-guard"],
+        "output-guards": ["privacy-guard"],
+        "security-guard": {
+            "type": "security",
+            "methods": ["prompt-injection-deberta-v3-base"]
+        },
+        "privacy-guard": {
+            "type": "privacy",
+            "methods": ["privacy-presidio"]
+        }
+    }
+)
+```
+
+---
+
+### dome_configs.delete_dome_config
+
+Deletes a guardrail configuration.
+
+#### Synopsis
+
+```python
+vijil.dome_configs.delete_dome_config(dome_config_id)
+```
+
+---
+
+## Detectors
+
+### detectors.list
+
+Lists available detection methods.
+
+#### Synopsis
+
+```python
+detectors = vijil.detectors.list()
+```
+
+---
+
+### detectors.get_detector_info
+
+Gets details for a specific detector.
+
+#### Synopsis
+
+```python
+info = vijil.detectors.get_detector_info(detector_id)
+```
+
+---
+
+## Error Handling
+
+The SDK raises typed exceptions for API errors:
+
+```python
+from vijil.exceptions import (
+    VijilAPIError,
+    AuthenticationError,
+    NotFoundError,
+    RateLimitError,
+    ValidationError
+)
+
+try:
+    results = vijil.evaluations.get_results("invalid-id")
+except NotFoundError as e:
+    print(f"Evaluation not found: {e}")
+except RateLimitError as e:
+    print(f"Rate limited, retry after: {e.retry_after}")
+except VijilAPIError as e:
+    print(f"API error: {e.status_code} - {e.message}")
+```
+
+---
+
+## See Also
+
+- [Evaluations API](/developer-guide/api/evaluations-api) — REST API reference
+- [Agents API](/developer-guide/api/agents-api) — REST API reference
+- [Dome API](/developer-guide/api/dome-api) — REST API reference
+- [Custom Agents](/developer-guide/frameworks/custom-agents) — Evaluate any Python agent

--- a/developer-guide/cicd/github-actions.mdx
+++ b/developer-guide/cicd/github-actions.mdx
@@ -1,0 +1,472 @@
+---
+title: 'GitHub Actions'
+description: 'Integrate Vijil evaluations into GitHub Actions workflows.'
+---
+
+Run Vijil evaluations automatically in your GitHub Actions workflows. This guide provides complete, copy-paste-ready workflow configurations.
+
+## Prerequisites
+
+1. Store M2M credentials as repository secrets (see [CI/CD Overview](/developer-guide/cicd/overview)):
+   - `M2M_CLIENT_ID`
+   - `M2M_CLIENT_SECRET`
+   - `M2M_CLIENT_TOKEN`
+
+2. Store your agent ID:
+   - `VIJIL_AGENT_ID`
+
+## Basic Workflow
+
+Evaluate on pull requests:
+
+```yaml
+# .github/workflows/vijil-evaluation.yml
+name: Vijil Evaluation
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install vijil requests
+
+      - name: Run evaluation
+        env:
+          M2M_CLIENT_ID: ${{ secrets.M2M_CLIENT_ID }}
+          M2M_CLIENT_SECRET: ${{ secrets.M2M_CLIENT_SECRET }}
+          M2M_CLIENT_TOKEN: ${{ secrets.M2M_CLIENT_TOKEN }}
+          VIJIL_AGENT_ID: ${{ secrets.VIJIL_AGENT_ID }}
+        run: |
+          python << 'EOF'
+          import os
+          import sys
+          import time
+          import requests
+          from vijil import Vijil
+
+          # Get access token
+          response = requests.post(
+              "https://api.vijil.ai/v1/auth/token",
+              json={
+                  "client_id": os.environ["M2M_CLIENT_ID"],
+                  "client_secret": os.environ["M2M_CLIENT_SECRET"],
+                  "client_token": os.environ["M2M_CLIENT_TOKEN"]
+              }
+          )
+          response.raise_for_status()
+          token = response.json()["access_token"]
+
+          # Run evaluation
+          vijil = Vijil(api_key=token)
+          evaluation = vijil.evaluations.create(
+              agent_id=os.environ["VIJIL_AGENT_ID"],
+              harnesses=["trust_score"]
+          )
+
+          # Wait for completion
+          from vijil.local_agents.constants import TERMINAL_STATUSES
+          while True:
+              status = vijil.evaluations.get_status(evaluation.get("id"))
+              if status.get("status") in TERMINAL_STATUSES:
+                  break
+              print(f"Progress: {status.get('progress', 0)}%")
+              time.sleep(30)
+
+          # Check results
+          results = vijil.evaluations.get_results(evaluation.get("id"))
+          trust_score = results.get("trust_score", 0) * 100
+
+          print(f"Trust Score: {trust_score:.1f}")
+
+          if trust_score < 75:
+              print("::error::Trust Score below threshold")
+              sys.exit(1)
+          EOF
+```
+
+## Quick Evaluation on Push
+
+Fast feedback on every commit:
+
+```yaml
+# .github/workflows/vijil-quick.yml
+name: Vijil Quick Check
+
+on:
+  push:
+    branches: [main, develop]
+
+jobs:
+  quick-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install vijil requests
+
+      - name: Quick evaluation
+        env:
+          M2M_CLIENT_ID: ${{ secrets.M2M_CLIENT_ID }}
+          M2M_CLIENT_SECRET: ${{ secrets.M2M_CLIENT_SECRET }}
+          M2M_CLIENT_TOKEN: ${{ secrets.M2M_CLIENT_TOKEN }}
+          VIJIL_AGENT_ID: ${{ secrets.VIJIL_AGENT_ID }}
+        run: |
+          python << 'EOF'
+          import os
+          import sys
+          import time
+          import requests
+          from vijil import Vijil
+
+          # Authenticate
+          response = requests.post(
+              "https://api.vijil.ai/v1/auth/token",
+              json={
+                  "client_id": os.environ["M2M_CLIENT_ID"],
+                  "client_secret": os.environ["M2M_CLIENT_SECRET"],
+                  "client_token": os.environ["M2M_CLIENT_TOKEN"]
+              }
+          )
+          token = response.json()["access_token"]
+
+          # Run quick evaluation
+          vijil = Vijil(api_key=token)
+          evaluation = vijil.evaluations.create(
+              agent_id=os.environ["VIJIL_AGENT_ID"],
+              harnesses=["security_Small"]  # Fast ~5 min evaluation
+          )
+
+          # Wait
+          from vijil.local_agents.constants import TERMINAL_STATUSES
+          while True:
+              status = vijil.evaluations.get_status(evaluation.get("id"))
+              if status.get("status") in TERMINAL_STATUSES:
+                  break
+              time.sleep(15)
+
+          # Report (warn only, don't block)
+          results = vijil.evaluations.get_results(evaluation.get("id"))
+          score = results.get("security_score", 0) * 100
+
+          if score < 70:
+              print(f"::warning::Security Score {score:.1f} below 70")
+          else:
+              print(f"Security Score: {score:.1f} - OK")
+          EOF
+```
+
+## PR Status Check with Summary
+
+Post evaluation summary to PR:
+
+```yaml
+# .github/workflows/vijil-pr-check.yml
+name: Vijil PR Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install vijil requests
+
+      - name: Run evaluation
+        id: eval
+        env:
+          M2M_CLIENT_ID: ${{ secrets.M2M_CLIENT_ID }}
+          M2M_CLIENT_SECRET: ${{ secrets.M2M_CLIENT_SECRET }}
+          M2M_CLIENT_TOKEN: ${{ secrets.M2M_CLIENT_TOKEN }}
+          VIJIL_AGENT_ID: ${{ secrets.VIJIL_AGENT_ID }}
+        run: |
+          python << 'EOF'
+          import os
+          import sys
+          import time
+          import requests
+          from vijil import Vijil
+
+          # Authenticate
+          response = requests.post(
+              "https://api.vijil.ai/v1/auth/token",
+              json={
+                  "client_id": os.environ["M2M_CLIENT_ID"],
+                  "client_secret": os.environ["M2M_CLIENT_SECRET"],
+                  "client_token": os.environ["M2M_CLIENT_TOKEN"]
+              }
+          )
+          token = response.json()["access_token"]
+
+          # Run evaluation
+          vijil = Vijil(api_key=token)
+          evaluation = vijil.evaluations.create(
+              agent_id=os.environ["VIJIL_AGENT_ID"],
+              harnesses=["trust_score"]
+          )
+
+          # Wait
+          from vijil.local_agents.constants import TERMINAL_STATUSES
+          while True:
+              status = vijil.evaluations.get_status(evaluation.get("id"))
+              if status.get("status") in TERMINAL_STATUSES:
+                  break
+              print(f"Progress: {status.get('progress', 0)}%")
+              time.sleep(30)
+
+          # Get results
+          results = vijil.evaluations.get_results(evaluation.get("id"))
+          trust = results.get("trust_score", 0) * 100
+          reliability = results.get("reliability_score", 0) * 100
+          security = results.get("security_score", 0) * 100
+          safety = results.get("safety_score", 0) * 100
+
+          # Write outputs
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"trust_score={trust:.1f}\n")
+              f.write(f"reliability={reliability:.1f}\n")
+              f.write(f"security={security:.1f}\n")
+              f.write(f"safety={safety:.1f}\n")
+              f.write(f"passed={'true' if trust >= 75 else 'false'}\n")
+
+          if trust < 75:
+              sys.exit(1)
+          EOF
+
+      - name: Post PR comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const passed = '${{ steps.eval.outputs.passed }}' === 'true';
+            const emoji = passed ? '✅' : '❌';
+            const status = passed ? 'PASSED' : 'FAILED';
+
+            const body = `## ${emoji} Vijil Evaluation ${status}
+
+            | Metric | Score | Threshold |
+            |--------|-------|-----------|
+            | **Trust Score** | ${{ steps.eval.outputs.trust_score }} | 75 |
+            | Reliability | ${{ steps.eval.outputs.reliability }} | - |
+            | Security | ${{ steps.eval.outputs.security }} | - |
+            | Safety | ${{ steps.eval.outputs.safety }} | - |
+
+            ${passed ? 'Agent meets trustworthiness requirements.' : '⚠️ Agent does not meet minimum Trust Score threshold.'}
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+```
+
+## Deployment Gate
+
+Block deployment on evaluation failure:
+
+```yaml
+# .github/workflows/deploy.yml
+name: Deploy with Evaluation Gate
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    outputs:
+      passed: ${{ steps.eval.outputs.passed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install vijil requests
+
+      - name: Run evaluation
+        id: eval
+        env:
+          M2M_CLIENT_ID: ${{ secrets.M2M_CLIENT_ID }}
+          M2M_CLIENT_SECRET: ${{ secrets.M2M_CLIENT_SECRET }}
+          M2M_CLIENT_TOKEN: ${{ secrets.M2M_CLIENT_TOKEN }}
+          VIJIL_AGENT_ID: ${{ secrets.VIJIL_AGENT_ID }}
+        run: |
+          # ... (same evaluation script as above)
+          echo "passed=true" >> $GITHUB_OUTPUT
+
+  deploy:
+    needs: evaluate
+    if: needs.evaluate.outputs.passed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to production
+        run: |
+          echo "Deploying agent to production..."
+          # Your deployment commands here
+```
+
+## Scheduled Regression Testing
+
+Run evaluations periodically:
+
+```yaml
+# .github/workflows/vijil-scheduled.yml
+name: Scheduled Trust Score Check
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6 AM UTC
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install vijil requests
+
+      - name: Run evaluation
+        env:
+          M2M_CLIENT_ID: ${{ secrets.M2M_CLIENT_ID }}
+          M2M_CLIENT_SECRET: ${{ secrets.M2M_CLIENT_SECRET }}
+          M2M_CLIENT_TOKEN: ${{ secrets.M2M_CLIENT_TOKEN }}
+          VIJIL_AGENT_ID: ${{ secrets.VIJIL_AGENT_ID }}
+        run: |
+          # ... evaluation script ...
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Vijil Evaluation Failed',
+              body: 'Scheduled Trust Score evaluation failed. Please investigate.',
+              labels: ['trust-score', 'automated']
+            });
+```
+
+## Reusable Workflow
+
+Create a reusable workflow for multiple agents:
+
+```yaml
+# .github/workflows/vijil-reusable.yml
+name: Vijil Evaluation (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      agent_id:
+        required: true
+        type: string
+      harness:
+        required: false
+        type: string
+        default: 'trust_score'
+      threshold:
+        required: false
+        type: number
+        default: 75
+    secrets:
+      M2M_CLIENT_ID:
+        required: true
+      M2M_CLIENT_SECRET:
+        required: true
+      M2M_CLIENT_TOKEN:
+        required: true
+    outputs:
+      trust_score:
+        value: ${{ jobs.evaluate.outputs.trust_score }}
+      passed:
+        value: ${{ jobs.evaluate.outputs.passed }}
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    outputs:
+      trust_score: ${{ steps.eval.outputs.trust_score }}
+      passed: ${{ steps.eval.outputs.passed }}
+    steps:
+      # ... evaluation steps using inputs.agent_id, inputs.harness, etc.
+```
+
+Call from other workflows:
+
+```yaml
+# .github/workflows/test-agent.yml
+jobs:
+  evaluate:
+    uses: ./.github/workflows/vijil-reusable.yml
+    with:
+      agent_id: ${{ secrets.VIJIL_AGENT_ID }}
+      harness: security
+      threshold: 80
+    secrets:
+      M2M_CLIENT_ID: ${{ secrets.M2M_CLIENT_ID }}
+      M2M_CLIENT_SECRET: ${{ secrets.M2M_CLIENT_SECRET }}
+      M2M_CLIENT_TOKEN: ${{ secrets.M2M_CLIENT_TOKEN }}
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="CI/CD Overview" icon="circle-nodes" href="/developer-guide/cicd/overview">
+    M2M authentication setup
+  </Card>
+  <Card title="GitLab CI" icon="gitlab" href="/developer-guide/cicd/gitlab-ci">
+    GitLab pipeline setup
+  </Card>
+  <Card title="Testing Strategies" icon="flask" href="/developer-guide/cicd/testing-strategies">
+    Advanced testing patterns
+  </Card>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Interpret evaluation results
+  </Card>
+</CardGroup>

--- a/developer-guide/cicd/gitlab-ci.mdx
+++ b/developer-guide/cicd/gitlab-ci.mdx
@@ -1,0 +1,414 @@
+---
+title: 'GitLab CI'
+description: 'Integrate Vijil evaluations into GitLab CI/CD pipelines.'
+---
+
+Run Vijil evaluations automatically in your GitLab CI/CD pipelines. This guide provides complete pipeline configurations.
+
+## Prerequisites
+
+1. Store M2M credentials as CI/CD variables (see [CI/CD Overview](/developer-guide/cicd/overview)):
+
+   Go to **Settings > CI/CD > Variables** and add:
+   - `M2M_CLIENT_ID` (masked)
+   - `M2M_CLIENT_SECRET` (masked)
+   - `M2M_CLIENT_TOKEN` (masked)
+   - `VIJIL_AGENT_ID`
+
+## Basic Pipeline
+
+Evaluate on merge requests:
+
+```yaml
+# .gitlab-ci.yml
+stages:
+  - test
+  - evaluate
+  - deploy
+
+vijil-evaluation:
+  stage: evaluate
+  image: python:3.11
+  script:
+    - pip install vijil requests
+    - |
+      python << 'EOF'
+      import os
+      import sys
+      import time
+      import requests
+      from vijil import Vijil
+
+      # Get access token
+      response = requests.post(
+          "https://api.vijil.ai/v1/auth/token",
+          json={
+              "client_id": os.environ["M2M_CLIENT_ID"],
+              "client_secret": os.environ["M2M_CLIENT_SECRET"],
+              "client_token": os.environ["M2M_CLIENT_TOKEN"]
+          }
+      )
+      response.raise_for_status()
+      token = response.json()["access_token"]
+
+      # Run evaluation
+      vijil = Vijil(api_key=token)
+      evaluation = vijil.evaluations.create(
+          agent_id=os.environ["VIJIL_AGENT_ID"],
+          harnesses=["trust_score"]
+      )
+
+      # Wait for completion
+      from vijil.local_agents.constants import TERMINAL_STATUSES
+      while True:
+          status = vijil.evaluations.get_status(evaluation.get("id"))
+          if status.get("status") in TERMINAL_STATUSES:
+              break
+          print(f"Progress: {status.get('progress', 0)}%")
+          time.sleep(30)
+
+      # Check results
+      results = vijil.evaluations.get_results(evaluation.get("id"))
+      trust_score = results.get("trust_score", 0) * 100
+
+      print(f"Trust Score: {trust_score:.1f}")
+
+      if trust_score < 75:
+          print("Trust Score below threshold")
+          sys.exit(1)
+      EOF
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+## Quick Check on Push
+
+Fast evaluation on every push:
+
+```yaml
+vijil-quick-check:
+  stage: test
+  image: python:3.11
+  script:
+    - pip install vijil requests
+    - |
+      python << 'EOF'
+      import os
+      import time
+      import requests
+      from vijil import Vijil
+
+      # Authenticate
+      response = requests.post(
+          "https://api.vijil.ai/v1/auth/token",
+          json={
+              "client_id": os.environ["M2M_CLIENT_ID"],
+              "client_secret": os.environ["M2M_CLIENT_SECRET"],
+              "client_token": os.environ["M2M_CLIENT_TOKEN"]
+          }
+      )
+      token = response.json()["access_token"]
+
+      # Quick security check
+      vijil = Vijil(api_key=token)
+      evaluation = vijil.evaluations.create(
+          agent_id=os.environ["VIJIL_AGENT_ID"],
+          harnesses=["security_Small"]
+      )
+
+      from vijil.local_agents.constants import TERMINAL_STATUSES
+      while True:
+          status = vijil.evaluations.get_status(evaluation.get("id"))
+          if status.get("status") in TERMINAL_STATUSES:
+              break
+          time.sleep(15)
+
+      results = vijil.evaluations.get_results(evaluation.get("id"))
+      score = results.get("security_score", 0) * 100
+      print(f"Security Score: {score:.1f}")
+      # Don't fail, just report
+      EOF
+  rules:
+    - if: $CI_COMMIT_BRANCH
+  allow_failure: true
+```
+
+## Merge Request Comments
+
+Post results as MR comments:
+
+```yaml
+vijil-evaluation:
+  stage: evaluate
+  image: python:3.11
+  script:
+    - pip install vijil requests
+    - |
+      python << 'EOF'
+      import os
+      import sys
+      import time
+      import requests
+      from vijil import Vijil
+
+      # Authenticate
+      response = requests.post(
+          "https://api.vijil.ai/v1/auth/token",
+          json={
+              "client_id": os.environ["M2M_CLIENT_ID"],
+              "client_secret": os.environ["M2M_CLIENT_SECRET"],
+              "client_token": os.environ["M2M_CLIENT_TOKEN"]
+          }
+      )
+      token = response.json()["access_token"]
+
+      # Run evaluation
+      vijil = Vijil(api_key=token)
+      evaluation = vijil.evaluations.create(
+          agent_id=os.environ["VIJIL_AGENT_ID"],
+          harnesses=["trust_score"]
+      )
+
+      from vijil.local_agents.constants import TERMINAL_STATUSES
+      while True:
+          status = vijil.evaluations.get_status(evaluation.get("id"))
+          if status.get("status") in TERMINAL_STATUSES:
+              break
+          time.sleep(30)
+
+      results = vijil.evaluations.get_results(evaluation.get("id"))
+      trust = results.get("trust_score", 0) * 100
+      reliability = results.get("reliability_score", 0) * 100
+      security = results.get("security_score", 0) * 100
+      safety = results.get("safety_score", 0) * 100
+
+      passed = trust >= 75
+      emoji = "✅" if passed else "❌"
+      status_text = "PASSED" if passed else "FAILED"
+
+      # Write results to file for comment
+      with open("results.md", "w") as f:
+          f.write(f"""## {emoji} Vijil Evaluation {status_text}
+
+      | Metric | Score | Threshold |
+      |--------|-------|-----------|
+      | **Trust Score** | {trust:.1f} | 75 |
+      | Reliability | {reliability:.1f} | - |
+      | Security | {security:.1f} | - |
+      | Safety | {safety:.1f} | - |
+
+      {"Agent meets trustworthiness requirements." if passed else "⚠️ Agent does not meet minimum Trust Score threshold."}
+      """)
+
+      if not passed:
+          sys.exit(1)
+      EOF
+    - |
+      if [ -n "$CI_MERGE_REQUEST_IID" ]; then
+        curl --request POST \
+          --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+          --form "body=$(cat results.md)" \
+          "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"
+      fi
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  artifacts:
+    paths:
+      - results.md
+    when: always
+```
+
+## Deployment Gate
+
+Block deployment on failure:
+
+```yaml
+stages:
+  - evaluate
+  - deploy
+
+vijil-gate:
+  stage: evaluate
+  image: python:3.11
+  script:
+    - pip install vijil requests
+    - python scripts/run_evaluation.py
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+
+deploy-production:
+  stage: deploy
+  script:
+    - echo "Deploying to production..."
+    # Your deployment commands
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  needs:
+    - vijil-gate
+```
+
+## Scheduled Evaluation
+
+Run daily regression tests:
+
+```yaml
+vijil-scheduled:
+  stage: evaluate
+  image: python:3.11
+  script:
+    - pip install vijil requests
+    - python scripts/run_evaluation.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+```
+
+Create a schedule in **CI/CD > Schedules** with cron expression `0 6 * * *` for daily at 6 AM.
+
+## Parallel Agent Evaluation
+
+Evaluate multiple agents simultaneously:
+
+```yaml
+.vijil-template: &vijil-template
+  stage: evaluate
+  image: python:3.11
+  script:
+    - pip install vijil requests
+    - python scripts/run_evaluation.py
+
+evaluate-agent-1:
+  <<: *vijil-template
+  variables:
+    VIJIL_AGENT_ID: $AGENT_1_ID
+
+evaluate-agent-2:
+  <<: *vijil-template
+  variables:
+    VIJIL_AGENT_ID: $AGENT_2_ID
+
+evaluate-agent-3:
+  <<: *vijil-template
+  variables:
+    VIJIL_AGENT_ID: $AGENT_3_ID
+```
+
+## JUnit Report Integration
+
+Generate JUnit-compatible reports for GitLab test reporting:
+
+```yaml
+vijil-evaluation:
+  stage: evaluate
+  image: python:3.11
+  script:
+    - pip install vijil requests junit-xml
+    - |
+      python << 'EOF'
+      import os
+      import time
+      import requests
+      from vijil import Vijil
+      from junit_xml import TestSuite, TestCase
+
+      # Authenticate and run evaluation
+      response = requests.post(
+          "https://api.vijil.ai/v1/auth/token",
+          json={
+              "client_id": os.environ["M2M_CLIENT_ID"],
+              "client_secret": os.environ["M2M_CLIENT_SECRET"],
+              "client_token": os.environ["M2M_CLIENT_TOKEN"]
+          }
+      )
+      token = response.json()["access_token"]
+
+      vijil = Vijil(api_key=token)
+      evaluation = vijil.evaluations.create(
+          agent_id=os.environ["VIJIL_AGENT_ID"],
+          harnesses=["trust_score"]
+      )
+
+      from vijil.local_agents.constants import TERMINAL_STATUSES
+      while True:
+          status = vijil.evaluations.get_status(evaluation.get("id"))
+          if status.get("status") in TERMINAL_STATUSES:
+              break
+          time.sleep(30)
+
+      results = vijil.evaluations.get_results(evaluation.get("id"))
+
+      # Generate JUnit report
+      test_cases = []
+
+      for metric in ["trust_score", "reliability_score", "security_score", "safety_score"]:
+          score = results.get(metric, 0) * 100
+          tc = TestCase(metric, classname="vijil")
+          if metric == "trust_score" and score < 75:
+              tc.add_failure_info(f"Score {score:.1f} below threshold 75")
+          test_cases.append(tc)
+
+      ts = TestSuite("Vijil Evaluation", test_cases)
+      with open("vijil-results.xml", "w") as f:
+          TestSuite.to_file(f, [ts])
+      EOF
+  artifacts:
+    reports:
+      junit: vijil-results.xml
+    when: always
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+```
+
+## Environment-Specific Thresholds
+
+Use different thresholds per environment:
+
+```yaml
+variables:
+  DEV_THRESHOLD: "60"
+  STAGING_THRESHOLD: "70"
+  PROD_THRESHOLD: "80"
+
+.vijil-base:
+  image: python:3.11
+  script:
+    - pip install vijil requests
+    - python scripts/run_evaluation.py --threshold $THRESHOLD
+
+vijil-dev:
+  extends: .vijil-base
+  variables:
+    THRESHOLD: $DEV_THRESHOLD
+  rules:
+    - if: $CI_COMMIT_BRANCH == "develop"
+
+vijil-staging:
+  extends: .vijil-base
+  variables:
+    THRESHOLD: $STAGING_THRESHOLD
+  rules:
+    - if: $CI_COMMIT_BRANCH == "staging"
+
+vijil-prod:
+  extends: .vijil-base
+  variables:
+    THRESHOLD: $PROD_THRESHOLD
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="CI/CD Overview" icon="circle-nodes" href="/developer-guide/cicd/overview">
+    M2M authentication setup
+  </Card>
+  <Card title="GitHub Actions" icon="github" href="/developer-guide/cicd/github-actions">
+    GitHub workflow setup
+  </Card>
+  <Card title="Testing Strategies" icon="flask" href="/developer-guide/cicd/testing-strategies">
+    Advanced testing patterns
+  </Card>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Interpret evaluation results
+  </Card>
+</CardGroup>

--- a/developer-guide/cicd/overview.mdx
+++ b/developer-guide/cicd/overview.mdx
@@ -1,0 +1,265 @@
+---
+title: 'CI/CD Overview'
+description: 'Automate agent evaluation and protection in your deployment pipeline.'
+---
+
+Integrate Vijil into your CI/CD pipeline to automatically evaluate agents before deployment and catch regressions early. This guide covers authentication setup and deployment strategies.
+
+## Why CI/CD Integration?
+
+| Benefit | Description |
+|---------|-------------|
+| **Automated testing** | Run evaluations on every PR or commit |
+| **Deployment gates** | Block deployments that fail Trust Score thresholds |
+| **Regression detection** | Catch trustworthiness regressions before production |
+| **Audit trail** | Document evaluation results for compliance |
+
+## Machine-to-Machine Authentication
+
+CI/CD pipelines require long-lived credentials since interactive login isn't possible. Vijil provides machine-to-machine (M2M) secrets for this purpose.
+
+### Obtaining M2M Secrets
+
+<Note>
+You must be an admin in your team to obtain M2M secrets.
+</Note>
+
+1. Log into the [Vijil Console](https://console.vijil.ai)
+2. Click your profile icon in the lower left
+3. Click **View long-lived token** (if not yet viewed) or **Rotate long-lived token** (if previously viewed)
+4. Save the three credentials:
+   - Client ID
+   - Client Secret
+   - Client Token
+
+<Warning>
+M2M secrets can only be viewed once. After viewing, you must rotate to see them again. Store them securely immediately.
+</Warning>
+
+### Storing Secrets in CI/CD
+
+Add these as secrets in your CI/CD platform:
+
+**GitHub Actions:**
+```
+Settings > Secrets and variables > Actions > New repository secret
+- M2M_CLIENT_ID
+- M2M_CLIENT_SECRET
+- M2M_CLIENT_TOKEN
+```
+
+**GitLab CI:**
+```
+Settings > CI/CD > Variables
+- M2M_CLIENT_ID (masked)
+- M2M_CLIENT_SECRET (masked)
+- M2M_CLIENT_TOKEN (masked)
+```
+
+### Obtaining an Access Token
+
+Use M2M secrets to get an access token for API calls:
+
+```python
+import requests
+import os
+
+def get_vijil_token():
+    """Exchange M2M credentials for an access token."""
+    payload = {
+        "client_id": os.environ["M2M_CLIENT_ID"],
+        "client_secret": os.environ["M2M_CLIENT_SECRET"],
+        "client_token": os.environ["M2M_CLIENT_TOKEN"]
+    }
+
+    response = requests.post(
+        "https://api.vijil.ai/v1/auth/token",
+        json=payload
+    )
+    response.raise_for_status()
+
+    return response.json()["access_token"]
+
+# Use the token
+os.environ["VIJIL_API_KEY"] = get_vijil_token()
+```
+
+<Note>
+Access tokens expire after 24 hours. For pipelines running longer than 24 hours, refresh the token before it expires.
+</Note>
+
+## Deployment Strategies
+
+### On Every Commit
+
+Fast feedback with quick evaluations:
+
+```yaml
+# Run on every push
+trigger: push
+harness: security_Small  # ~5 minutes
+threshold: 70
+action: warn  # Don't block, just report
+```
+
+### On Pull Request
+
+Standard evaluation before merge:
+
+```yaml
+# Run on PR
+trigger: pull_request
+harness: trust_score  # ~30 minutes
+threshold: 75
+action: require  # Block merge if failed
+```
+
+### Before Production Deployment
+
+Comprehensive evaluation for production:
+
+```yaml
+# Run before deploy
+trigger: deploy
+harness: trust_score
+threshold: 80
+action: require
+notify: security-team@company.com
+```
+
+## Evaluation Script Template
+
+Reusable script for any CI/CD platform:
+
+```python
+#!/usr/bin/env python3
+"""Run Vijil evaluation in CI/CD pipeline."""
+
+import os
+import sys
+import requests
+from vijil import Vijil
+
+def get_token():
+    """Get access token from M2M credentials."""
+    response = requests.post(
+        "https://api.vijil.ai/v1/auth/token",
+        json={
+            "client_id": os.environ["M2M_CLIENT_ID"],
+            "client_secret": os.environ["M2M_CLIENT_SECRET"],
+            "client_token": os.environ["M2M_CLIENT_TOKEN"]
+        }
+    )
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+def main():
+    # Configuration from environment
+    agent_id = os.environ.get("VIJIL_AGENT_ID")
+    harness = os.environ.get("VIJIL_HARNESS", "trust_score")
+    threshold = float(os.environ.get("VIJIL_THRESHOLD", "75"))
+
+    # Authenticate
+    token = get_token()
+    vijil = Vijil(api_key=token)
+
+    # Run evaluation
+    print(f"Starting evaluation for agent {agent_id}...")
+    evaluation = vijil.evaluations.create(
+        agent_id=agent_id,
+        harnesses=[harness]
+    )
+
+    # Wait for completion
+    from vijil.local_agents.constants import TERMINAL_STATUSES
+    import time
+
+    while True:
+        status = vijil.evaluations.get_status(evaluation.get("id"))
+        if status.get("status") in TERMINAL_STATUSES:
+            break
+        print(f"Progress: {status.get('progress', 0)}%")
+        time.sleep(30)
+
+    # Get results
+    results = vijil.evaluations.get_results(evaluation.get("id"))
+    trust_score = results.get("trust_score", 0) * 100
+
+    # Report results
+    print(f"\n{'='*50}")
+    print(f"Trust Score: {trust_score:.1f}")
+    print(f"Reliability: {results.get('reliability_score', 0) * 100:.1f}")
+    print(f"Security: {results.get('security_score', 0) * 100:.1f}")
+    print(f"Safety: {results.get('safety_score', 0) * 100:.1f}")
+    print(f"Threshold: {threshold}")
+    print(f"{'='*50}\n")
+
+    # Check threshold
+    if trust_score < threshold:
+        print(f"FAILED: Trust Score {trust_score:.1f} < {threshold}")
+        sys.exit(1)
+    else:
+        print(f"PASSED: Trust Score {trust_score:.1f} >= {threshold}")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+## Threshold Guidelines
+
+| Environment | Trust Score | Security | Notes |
+|-------------|-------------|----------|-------|
+| Development | ≥ 60 | ≥ 60 | Permissive for iteration |
+| Staging | ≥ 70 | ≥ 75 | Catch issues before prod |
+| Production | ≥ 80 | ≥ 85 | Strict for safety |
+
+## Integration Patterns
+
+### Block on Failure
+
+Prevent deployment when evaluation fails:
+
+```python
+if trust_score < threshold:
+    sys.exit(1)  # Non-zero exit code blocks pipeline
+```
+
+### Warn but Allow
+
+Report results without blocking:
+
+```python
+if trust_score < threshold:
+    print("::warning::Trust Score below threshold")
+    # Exit 0 to allow pipeline to continue
+```
+
+### Require Approval
+
+For scores in a gray zone, require manual review:
+
+```python
+if trust_score < hard_threshold:
+    sys.exit(1)  # Block
+elif trust_score < soft_threshold:
+    print("::warning::Manual approval required")
+    # Set output for approval workflow
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="GitHub Actions" icon="github" href="/developer-guide/cicd/github-actions">
+    Complete GitHub Actions setup
+  </Card>
+  <Card title="GitLab CI" icon="gitlab" href="/developer-guide/cicd/gitlab-ci">
+    Complete GitLab CI setup
+  </Card>
+  <Card title="Testing Strategies" icon="flask" href="/developer-guide/cicd/testing-strategies">
+    Advanced testing patterns
+  </Card>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Evaluation API reference
+  </Card>
+</CardGroup>

--- a/developer-guide/cicd/testing-strategies.mdx
+++ b/developer-guide/cicd/testing-strategies.mdx
@@ -1,0 +1,393 @@
+---
+title: 'Testing Strategies'
+description: 'Best practices for automated agent testing in CI/CD pipelines.'
+---
+
+Design effective testing strategies that balance thoroughness with speed. This guide covers testing patterns, threshold management, and regression detection.
+
+## Testing Pyramid
+
+Balance different evaluation depths across your pipeline:
+
+```
+                 ┌─────────────────┐
+                 │   Production    │  Full trust_score
+                 │   Deployment    │  Threshold: 80+
+                 └────────┬────────┘
+                 ┌────────┴────────┐
+                 │  Pull Request   │  Standard harnesses
+                 │    Merge        │  Threshold: 75
+                 └────────┬────────┘
+                 ┌────────┴────────┐
+                 │   Every Commit  │  Quick _Small harnesses
+                 │     Push        │  Warn only
+                 └─────────────────┘
+```
+
+## Evaluation Depth by Trigger
+
+### On Every Commit
+
+Fast feedback for developers:
+
+```python
+COMMIT_CONFIG = {
+    "harness": "security_Small",  # ~5 minutes
+    "threshold": 60,
+    "action": "warn",  # Don't block
+    "timeout_minutes": 10
+}
+```
+
+### On Pull Request
+
+Standard evaluation before merge:
+
+```python
+PR_CONFIG = {
+    "harness": "trust_score",  # ~30 minutes
+    "threshold": 75,
+    "action": "require",  # Block merge
+    "timeout_minutes": 60
+}
+```
+
+### Before Production Deployment
+
+Comprehensive validation:
+
+```python
+DEPLOY_CONFIG = {
+    "harness": "trust_score",
+    "threshold": 80,
+    "action": "require",
+    "timeout_minutes": 120,
+    "notify": ["security@company.com"]
+}
+```
+
+## Threshold Management
+
+### Define Thresholds
+
+```python
+THRESHOLDS = {
+    "trust_score": 75,
+    "reliability_score": 70,
+    "security_score": 80,  # Stricter for security
+    "safety_score": 75
+}
+
+SEVERITY_LIMITS = {
+    "critical": 0,  # No critical allowed
+    "high": 2,      # Max 2 high severity
+    "medium": 10,   # Max 10 medium
+    "low": None     # Unlimited
+}
+```
+
+### Check Thresholds
+
+```python
+def check_evaluation_passed(results: dict) -> tuple[bool, list[str]]:
+    """Check if results meet all threshold requirements."""
+    failures = []
+
+    # Check dimension scores
+    for metric, threshold in THRESHOLDS.items():
+        score = results.get(metric, 0) * 100
+        if score < threshold:
+            failures.append(f"{metric}: {score:.1f} < {threshold}")
+
+    # Check severity limits
+    findings = results.get("failures", [])
+    severity_counts = {}
+    for f in findings:
+        sev = f.get("severity", "unknown")
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+    for severity, limit in SEVERITY_LIMITS.items():
+        if limit is not None:
+            count = severity_counts.get(severity, 0)
+            if count > limit:
+                failures.append(f"{severity} findings: {count} > {limit}")
+
+    return len(failures) == 0, failures
+```
+
+### Environment-Specific Thresholds
+
+```python
+import os
+
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "development")
+
+THRESHOLD_BY_ENV = {
+    "development": {"trust_score": 60, "security_score": 65},
+    "staging": {"trust_score": 70, "security_score": 75},
+    "production": {"trust_score": 80, "security_score": 85}
+}
+
+def get_thresholds() -> dict:
+    return THRESHOLD_BY_ENV.get(ENVIRONMENT, THRESHOLD_BY_ENV["development"])
+```
+
+## Regression Detection
+
+### Track Baseline Scores
+
+Store baseline scores for comparison:
+
+```python
+import json
+from pathlib import Path
+
+BASELINE_FILE = Path(".vijil-baseline.json")
+
+def save_baseline(results: dict):
+    """Save current results as baseline."""
+    baseline = {
+        "trust_score": results.get("trust_score"),
+        "reliability_score": results.get("reliability_score"),
+        "security_score": results.get("security_score"),
+        "safety_score": results.get("safety_score"),
+        "timestamp": results.get("completed_at")
+    }
+    BASELINE_FILE.write_text(json.dumps(baseline, indent=2))
+
+def load_baseline() -> dict | None:
+    """Load saved baseline."""
+    if BASELINE_FILE.exists():
+        return json.loads(BASELINE_FILE.read_text())
+    return None
+```
+
+### Detect Regression
+
+```python
+REGRESSION_THRESHOLD = 0.05  # 5 point drop triggers regression
+
+def check_regression(current: dict, baseline: dict) -> list[str]:
+    """Check for score regressions against baseline."""
+    regressions = []
+
+    for metric in ["trust_score", "reliability_score", "security_score", "safety_score"]:
+        current_score = current.get(metric, 0)
+        baseline_score = baseline.get(metric, 0)
+        delta = current_score - baseline_score
+
+        if delta < -REGRESSION_THRESHOLD:
+            regressions.append(
+                f"{metric}: {baseline_score*100:.1f} -> {current_score*100:.1f} "
+                f"(Δ{delta*100:+.1f})"
+            )
+
+    return regressions
+
+# Usage
+baseline = load_baseline()
+if baseline:
+    regressions = check_regression(results, baseline)
+    if regressions:
+        print("Regressions detected:")
+        for r in regressions:
+            print(f"  - {r}")
+        sys.exit(1)
+```
+
+## Parallel Testing
+
+### Multiple Agents
+
+Evaluate multiple agents simultaneously:
+
+```python
+import asyncio
+from vijil import Vijil
+
+async def evaluate_agents(agent_ids: list[str], harness: str):
+    """Run evaluations for multiple agents in parallel."""
+    vijil = Vijil()
+
+    # Start all evaluations
+    evaluations = []
+    for agent_id in agent_ids:
+        eval_result = vijil.evaluations.create(
+            agent_id=agent_id,
+            harnesses=[harness]
+        )
+        evaluations.append(eval_result)
+
+    # Wait for all to complete
+    from vijil.local_agents.constants import TERMINAL_STATUSES
+    results = []
+    for evaluation in evaluations:
+        while True:
+            status = vijil.evaluations.get_status(evaluation.get("id"))
+            if status.get("status") in TERMINAL_STATUSES:
+                break
+            await asyncio.sleep(10)
+
+        result = vijil.evaluations.get_results(evaluation.get("id"))
+        results.append(result)
+
+    return results
+
+# Run
+agents = ["agent-1", "agent-2", "agent-3"]
+all_results = asyncio.run(evaluate_agents(agents, "security_Small"))
+```
+
+### Multiple Harnesses
+
+Run different harnesses in parallel:
+
+```python
+async def comprehensive_evaluation(agent_id: str):
+    """Run multiple harnesses in parallel for comprehensive coverage."""
+    vijil = Vijil()
+    harnesses = ["security", "reliability", "safety"]
+
+    evaluations = [
+        vijil.evaluations.create(agent_id=agent_id, harnesses=[h])
+        for h in harnesses
+    ]
+
+    # Wait and collect results
+    # ...
+```
+
+## Incremental Testing
+
+### Changed Files Only
+
+Focus testing on changed components:
+
+```python
+import subprocess
+
+def get_changed_files() -> list[str]:
+    """Get files changed in current PR/commit."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main"],
+        capture_output=True,
+        text=True
+    )
+    return result.stdout.strip().split("\n")
+
+def select_harnesses(changed_files: list[str]) -> list[str]:
+    """Select harnesses based on what changed."""
+    harnesses = set()
+
+    for file in changed_files:
+        if "prompt" in file or "system" in file:
+            harnesses.add("security")
+        if "model" in file or "llm" in file:
+            harnesses.add("reliability")
+        if "output" in file or "response" in file:
+            harnesses.add("safety")
+
+    # Always include at least one harness
+    if not harnesses:
+        harnesses.add("security_Small")
+
+    return list(harnesses)
+```
+
+## Flaky Test Handling
+
+### Retry Logic
+
+Handle transient failures:
+
+```python
+MAX_RETRIES = 3
+RETRY_DELAY = 60  # seconds
+
+def run_evaluation_with_retry(vijil, agent_id: str, harness: str):
+    """Run evaluation with retry logic."""
+    for attempt in range(MAX_RETRIES):
+        try:
+            evaluation = vijil.evaluations.create(
+                agent_id=agent_id,
+                harnesses=[harness]
+            )
+
+            # Wait for completion
+            from vijil.local_agents.constants import TERMINAL_STATUSES
+            while True:
+                status = vijil.evaluations.get_status(evaluation.get("id"))
+                if status.get("status") in TERMINAL_STATUSES:
+                    break
+                time.sleep(30)
+
+            results = vijil.evaluations.get_results(evaluation.get("id"))
+
+            if status.get("status") == "completed":
+                return results
+
+        except Exception as e:
+            print(f"Attempt {attempt + 1} failed: {e}")
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(RETRY_DELAY)
+
+    raise Exception(f"Evaluation failed after {MAX_RETRIES} attempts")
+```
+
+## Reporting
+
+### Generate Summary Report
+
+```python
+def generate_report(results: dict) -> str:
+    """Generate a markdown summary report."""
+    trust = results.get("trust_score", 0) * 100
+    reliability = results.get("reliability_score", 0) * 100
+    security = results.get("security_score", 0) * 100
+    safety = results.get("safety_score", 0) * 100
+
+    passed = trust >= THRESHOLDS["trust_score"]
+    status = "PASSED" if passed else "FAILED"
+    emoji = "✅" if passed else "❌"
+
+    failures = results.get("failures", [])
+    critical = sum(1 for f in failures if f.get("severity") == "critical")
+    high = sum(1 for f in failures if f.get("severity") == "high")
+
+    report = f"""## {emoji} Vijil Evaluation {status}
+
+| Metric | Score | Threshold | Status |
+|--------|-------|-----------|--------|
+| Trust Score | {trust:.1f} | {THRESHOLDS['trust_score']} | {'✓' if trust >= THRESHOLDS['trust_score'] else '✗'} |
+| Reliability | {reliability:.1f} | {THRESHOLDS['reliability_score']} | {'✓' if reliability >= THRESHOLDS['reliability_score'] else '✗'} |
+| Security | {security:.1f} | {THRESHOLDS['security_score']} | {'✓' if security >= THRESHOLDS['security_score'] else '✗'} |
+| Safety | {safety:.1f} | {THRESHOLDS['safety_score']} | {'✓' if safety >= THRESHOLDS['safety_score'] else '✗'} |
+
+### Findings Summary
+- Critical: {critical}
+- High: {high}
+- Total: {len(failures)}
+"""
+
+    if not passed:
+        report += "\n⚠️ **Action Required**: Address failures before merging.\n"
+
+    return report
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="CI/CD Overview" icon="circle-nodes" href="/developer-guide/cicd/overview">
+    Pipeline setup basics
+  </Card>
+  <Card title="GitHub Actions" icon="github" href="/developer-guide/cicd/github-actions">
+    GitHub workflow examples
+  </Card>
+  <Card title="GitLab CI" icon="gitlab" href="/developer-guide/cicd/gitlab-ci">
+    GitLab pipeline examples
+  </Card>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Interpret evaluation results
+  </Card>
+</CardGroup>

--- a/developer-guide/enterprise/configuration.mdx
+++ b/developer-guide/enterprise/configuration.mdx
@@ -1,0 +1,70 @@
+---
+title: "Deploying Vijil with Helm"
+description: ""
+---
+Now that you have provisioned an EKS cluster and ensured connectivity to the required AWS resources—**PostgreSQL** (Aurora or RDS), **OpenSearch/Elasticsearch**, and **S3**—you are ready to deploy **Vijil** using Vijil's Helm chart.
+
+## Prerequisites
+
+- An **EKS cluster** with the necessary IAM permissions and networking configuration.
+- Access to a PostgreSQL-compatible database (**Aurora or RDS**).
+- Access to an **OpenSearch or Elasticsearch** domain.
+- **S3** buckets for object storage.
+- An **Auth0** application for authenticating with all APIs
+- Access to the private **`vijil-eks`** GitHub repository. If you do not have access, please contact the Vijil team.
+
+## Deploying the Helm Chart
+
+The deployment of Vijil Evaluate is managed via a Helm chart provided in the `vijil-eks` GitHub repository that you will need to contact Vijil in order to gain access to. The repository contains a `README.md` with instructions for configuring and deploying the chart.
+
+### Steps Overview
+
+1. **Clone the Repository**
+
+```bash title="Shell"
+git clone git@github.com:vijil-ai/vijil-eks.git
+cd vijil-eks
+```
+
+2. **Review the README**
+
+The `README.md` in the repository contains the most up-to-date and detailed deployment instructions, including required values, configuration options, and example commands.
+
+3. **Configure Your Values**
+
+Prepare a `values.yaml` and `secrets.yaml` file with the necessary configuration for your environment. This includes database connection strings, OpenSearch endpoints, S3 bucket names, and any other required secrets or settings. There are examples in the `vijil-eks` repository for you to follow.
+
+4. **Install the Helm Chart**
+
+Follow the instructions in the `README.md` to install the chart, for example:
+
+```bash title="Shell"
+helm upgrade --install  eval . -f values/dev.yaml -f values/secrets/dev.yaml
+```
+
+It should take around 10-15m to deploy.
+
+<Note>
+The actual command and chart path may vary; always refer to the repository's `README.md` for the latest instructions.
+</Note>
+
+5. **Verify the Deployment**
+
+After installation, monitor the pods and services in your EKS cluster to ensure that all components are running as expected.
+
+```bash title="Shell"
+kubectl get pods
+kubectl get svc
+kubectl get ingress
+```
+When you fetch the ingress defintions, you should see 2 Load Balancers with DNS. You will want to add those DNS entries under the Route53 entries you desire in your AWS account, so that you can access the API and Web UI through the domain names that you want.
+You should be able to verify that the API is up and running by hitting the `/healthz` endpoint
+
+## Next Steps
+
+- For advanced configuration, troubleshooting, and upgrade instructions, consult the `vijil-eks` repository documentation.
+- If you encounter issues or need support, please reach out to the Vijil team.
+
+<Note>
+The Helm chart and deployment scripts are actively maintained. Always refer to the `vijil-eks` repository for the latest best practices and updates.
+</Note>

--- a/developer-guide/enterprise/overview.mdx
+++ b/developer-guide/enterprise/overview.mdx
@@ -1,0 +1,120 @@
+---
+title: 'Self-Hosting Vijil'
+description: 'Deploy Vijil in your own infrastructure for data residency, compliance, or air-gapped environments.'
+---
+
+Most teams use Vijil's cloud platform at [console.vijil.ai](https://console.vijil.ai). But some organizations need to run Vijil in their own infrastructure—for data residency requirements, regulatory compliance, or environments without internet access.
+
+This section covers self-hosted deployment. If you're evaluating whether self-hosting is right for you, start with the qualifying questions below.
+
+## Is Self-Hosting Right for You?
+
+Self-hosting adds operational complexity. Consider it when you have specific requirements that the cloud platform can't meet:
+
+| Requirement | Cloud Platform | Self-Hosted |
+|-------------|----------------|-------------|
+| Data never leaves your infrastructure | No | Yes |
+| Air-gapped / no internet connectivity | No | Yes |
+| Custom SSO/SAML integration | Limited | Full |
+| Deploy in specific cloud regions | Limited | Yes |
+| Customer-managed encryption keys | No | Yes |
+| Compliance with internal security policies | Depends | Yes |
+
+<Note>
+If your primary concern is data privacy, note that the cloud platform doesn't store your agent's responses—only evaluation metadata. Contact [contact@vijil.ai](mailto:contact@vijil.ai) to discuss your specific requirements before committing to self-hosting.
+</Note>
+
+## System Architecture
+
+Vijil consists of three main components that run in your Kubernetes cluster:
+
+<img src="/images/enterprise-architecture.svg" alt="Vijil system architecture showing Diamond, Dome, and Console components" style={{maxWidth: '700px', margin: '2rem auto', display: 'block'}} />
+
+### Components
+
+| Component | Purpose | Resource Requirements |
+|-----------|---------|----------------------|
+| **Diamond** | Evaluation engine. Sends probes to agents, analyzes responses, generates Trust Scores. | CPU-intensive during evaluations |
+| **Dome** | Runtime protection. Intercepts agent inputs/outputs and applies guardrails. | Low latency required |
+| **Console** | Web UI. Manage agents, view results, configure guardrails. | Standard web application |
+
+### Data Stores
+
+| Store | Purpose | Options |
+|-------|---------|---------|
+| **PostgreSQL** | Application data, evaluation results, configuration | Amazon Aurora, RDS, or self-managed |
+| **OpenSearch** | Search and analytics for evaluation data | Amazon OpenSearch or self-managed Elasticsearch |
+| **Object Storage** | Artifacts, configs, file uploads | S3, GCS, Azure Blob, or MinIO |
+
+### External Dependencies
+
+| Service | Purpose | Required |
+|---------|---------|----------|
+| **Auth0** | User authentication and SSO | Yes |
+| **LLM Providers** | Your agents' underlying models | Depends on your agents |
+
+## Roles and Permissions
+
+Deploying Vijil requires coordination across teams:
+
+| Role | Responsibilities |
+|------|------------------|
+| **Kubernetes Admin** | Create cluster, configure networking, manage deployments |
+| **Cloud IAM Admin** | Create service accounts, configure permissions for AWS/GCP/Azure resources |
+| **Database Admin** | Provision PostgreSQL and OpenSearch, configure backups |
+| **Security/Network** | Configure VPC, security groups, firewall rules, TLS certificates |
+| **Auth0 Admin** | Create application, configure SSO integration |
+
+<Tip>
+In smaller organizations, one platform engineer may cover multiple roles. The key is ensuring someone has permissions to provision each resource type.
+</Tip>
+
+## Deployment Options
+
+### VPC Deployment
+
+Run Vijil in your cloud provider's VPC with private networking:
+
+- **Supported**: AWS EKS, GCP GKE, Azure AKS
+- **Networking**: Private subnets, VPC peering to your agent infrastructure
+- **Data**: Customer-managed encryption keys, data stays in your account
+- **Updates**: Managed by Vijil team with your approval
+
+### Air-Gapped Deployment
+
+Fully isolated with no internet connectivity:
+
+- **Networking**: No external access required after initial setup
+- **Updates**: Manual artifact transfer for updates
+- **LLM Access**: Requires on-premises LLM or private endpoints
+- **Support**: Offline documentation, scheduled support windows
+
+## What's Involved
+
+A typical self-hosted deployment takes 2–4 weeks:
+
+1. **Prerequisites** (Week 1) — Provision infrastructure, configure networking
+2. **Deployment** (Week 2) — Install Vijil components, configure data stores
+3. **Integration** (Week 3) — Connect Auth0, test agent connectivity
+4. **Validation** (Week 4) — Run test evaluations, verify guardrail functionality
+
+<Warning>
+Self-hosted deployments require an enterprise agreement. Contact [contact@vijil.ai](mailto:contact@vijil.ai) to discuss pricing and support terms before beginning infrastructure work.
+</Warning>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Prerequisites" icon="clipboard-check" href="/developer-guide/enterprise/prerequisites">
+    Infrastructure requirements and team checklist
+  </Card>
+  <Card title="Deployment Guide" icon="server" href="/developer-guide/enterprise/self-hosted">
+    Step-by-step installation instructions
+  </Card>
+  <Card title="Configuration" icon="gear" href="/developer-guide/enterprise/configuration">
+    Helm values and environment variables
+  </Card>
+  <Card title="Contact Sales" icon="envelope" href="mailto:contact@vijil.ai">
+    Discuss enterprise pricing and support
+  </Card>
+</CardGroup>

--- a/developer-guide/enterprise/prerequisites.mdx
+++ b/developer-guide/enterprise/prerequisites.mdx
@@ -1,0 +1,113 @@
+---
+title: "Prerequisites"
+description: "Infrastructure requirements, team skills, and checklist for self-hosted deployment."
+---
+
+This page helps you assess readiness for a self-hosted Vijil deployment. Complete this checklist before beginning infrastructure work.
+
+## Team Readiness
+
+Self-hosted deployment requires coordination across multiple teams. Verify you have access to people with these skills:
+
+| Skill Area | Required For | Can You Access? |
+|------------|--------------|-----------------|
+| Kubernetes administration | Cluster setup, Helm deployments, troubleshooting | Required |
+| Cloud IAM (AWS/GCP/Azure) | Service accounts, role policies, cross-service permissions | Required |
+| Database administration | PostgreSQL provisioning, backup configuration | Required |
+| Network/Security | VPC configuration, security groups, TLS certificates | Required |
+| Auth0 administration | Application setup, SSO configuration | Required |
+
+<Note>
+In smaller organizations, one platform engineer may cover multiple areas. The critical factor is having someone with permissions to provision each resource type.
+</Note>
+
+## Timeline Expectations
+
+A typical deployment takes 2–4 weeks:
+
+| Phase | Duration | Activities |
+|-------|----------|------------|
+| Prerequisites | 1 week | Provision infrastructure, configure networking |
+| Deployment | 1 week | Install Vijil, configure data stores |
+| Integration | 1 week | Connect Auth0, test agent connectivity |
+| Validation | 3–5 days | Test evaluations, verify guardrails |
+
+Factor in additional time if you need to request cloud resources through an internal procurement process.
+
+## Infrastructure Requirements
+
+Before deploying Vijil, ensure you have the following resources available:
+
+- **AWS Account**: You must have access to an AWS account with sufficient permissions to create and manage EKS clusters, RDS/Aurora databases, OpenSearch domains, and S3 buckets.
+- **AWS CLI**: Install and configure the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) on your local machine.
+- **kubectl**: Install [kubectl](https://kubernetes.io/docs/tasks/tools/) to interact with your Kubernetes cluster.
+- **IAM Permissions**: Ensure your AWS user/role has permissions to create and manage EKS, RDS/Aurora, OpenSearch, and S3 resources.
+- **Basic Kubernetes Knowledge**: Familiarity with Kubernetes concepts and resource management is required.
+- **Networking**: Understanding of VPC, subnets, and security groups in AWS.
+
+## Dependencies
+
+The following AWS resources and services are required for a production deployment of Vijil Evaluate:
+
+### Core
+
+- **Amazon EKS Cluster**: The primary compute environment for running Vijil Evaluate services.
+
+### Datastores
+
+- **PostgreSQL Database**: Used for persistent storage of application data. This can be provisioned using:
+  - **Amazon Aurora (PostgreSQL-compatible)** – recommended for high availability and scalability.
+  - **Amazon RDS for PostgreSQL** – suitable for smaller-scale or non-production deployments.
+  - Any other PostgreSQL solution you want that your EKS cluster has permission to access
+
+- **Amazon OpenSearch Service**: Provides search and analytics capabilities (Elasticsearch-compatible). Required for indexing and querying evaluation data.
+
+### Object Storage
+
+- **Amazon S3**: Necessary for storing artifacts and handling data uploads for harness creations and other funcitonality. You will need to create three S3 buckets:
+  1. **Evaluation Data Bucket** – for storing evaluation results and related data.
+  2. **Configs Bucket** – for storing configuration files required by the vijil-evaluate service.
+  3. **File Uploads Bucket** – for handling file uploads, such as files used in harness creation.
+
+    For the file uploads bucket you will also need to go to the control panel of this bucket and add CORS configurations, such that it is able to accept signed URL file uploads from your browser. Below is an example of what to add in an AWS S3 bucket's CORS configuration (it will be very similar in the cloud storage equivalents of other cloud providers):
+    ```json title="JSON"
+    [
+      {
+          "AllowedHeaders": [
+              "*"
+          ],
+          "AllowedMethods": [
+              "GET",
+              "PUT",
+              "POST",
+              "HEAD"
+          ],
+          "AllowedOrigins": [
+              "https://*.yourdomain.com"
+          ],
+          "ExposeHeaders": [
+              "ETag",
+              "x-amz-request-id",
+              "x-amz-id-2"
+          ],
+          "MaxAgeSeconds": 3000
+      }
+    ]
+    ```
+
+### Authentication
+
+- **Auth0** - You will require an Auth0 account and the ability to create an Auth0 application in your tenant
+
+## Summary Table
+
+| Dependency         | AWS Service                | Purpose                                 |
+|--------------------|---------------------------|-----------------------------------------|
+| Compute            | EKS                       | Run Vijil Evaluate workloads            |
+| Relational DB      | Aurora/RDS (PostgreSQL)   | Persistent application data             |
+| Search/Analytics   | OpenSearch                | Indexing and querying evaluation data   |
+| Object Storage     | S3                        | Store artifacts, logs, and backups      |
+
+> **Note:** All resources should be provisioned in the same AWS region for optimal performance and cost efficiency.
+
+Once these pre-requisites and dependencies are in place, you can proceed to the deployment steps.

--- a/developer-guide/enterprise/self-hosted.mdx
+++ b/developer-guide/enterprise/self-hosted.mdx
@@ -1,0 +1,293 @@
+---
+title: 'Deployment Guide'
+description: 'Step-by-step instructions for deploying Vijil in your Kubernetes cluster.'
+---
+
+This guide walks through deploying Vijil in your own infrastructure. Before starting, ensure you've completed the [prerequisites](/developer-guide/enterprise/prerequisites) and have an enterprise agreement in place.
+
+## Deployment Overview
+
+Vijil deploys as a set of Helm charts to your Kubernetes cluster. The deployment connects to your provisioned data stores (PostgreSQL, OpenSearch, S3) and integrates with Auth0 for authentication.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Your Kubernetes Cluster                   │
+│                                                              │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐          │
+│  │   Diamond   │  │    Dome     │  │   Console   │          │
+│  │  (eval)     │  │  (protect)  │  │    (UI)     │          │
+│  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘          │
+│         │                │                │                  │
+│         └────────────────┴────────────────┘                  │
+│                          │                                   │
+└──────────────────────────┼───────────────────────────────────┘
+                           │
+        ┌──────────────────┼──────────────────┐
+        │                  │                  │
+   ┌────┴────┐      ┌──────┴──────┐    ┌─────┴─────┐
+   │PostgreSQL│      │ OpenSearch  │    │    S3     │
+   └──────────┘      └─────────────┘    └───────────┘
+```
+
+## AWS EKS Deployment
+
+This is the primary deployment path. GCP GKE and Azure AKS follow similar patterns.
+
+### Step 1: Configure kubectl
+
+Ensure you can access your EKS cluster:
+
+```bash
+aws eks update-kubeconfig --region <region> --name <cluster-name>
+kubectl get nodes
+```
+
+### Step 2: Create Namespace
+
+```bash
+kubectl create namespace vijil
+```
+
+### Step 3: Add Vijil Helm Repository
+
+```bash
+helm repo add vijil https://charts.vijil.ai
+helm repo update
+```
+
+### Step 4: Create Secrets
+
+Create secrets for your data store credentials:
+
+```bash
+kubectl create secret generic vijil-db-credentials \
+  --namespace vijil \
+  --from-literal=host=<aurora-endpoint> \
+  --from-literal=port=5432 \
+  --from-literal=username=<username> \
+  --from-literal=password=<password> \
+  --from-literal=database=vijil
+
+kubectl create secret generic vijil-opensearch-credentials \
+  --namespace vijil \
+  --from-literal=host=<opensearch-endpoint> \
+  --from-literal=username=<username> \
+  --from-literal=password=<password>
+
+kubectl create secret generic vijil-s3-credentials \
+  --namespace vijil \
+  --from-literal=bucket=<bucket-name> \
+  --from-literal=region=<region>
+```
+
+### Step 5: Configure Values
+
+Create a `values.yaml` file for your deployment:
+
+```yaml
+global:
+  domain: vijil.your-company.com
+
+diamond:
+  replicas: 2
+  resources:
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+    limits:
+      cpu: "4"
+      memory: "8Gi"
+
+dome:
+  replicas: 3
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+
+console:
+  replicas: 2
+
+auth0:
+  domain: your-tenant.auth0.com
+  clientId: <client-id>
+  audience: https://api.vijil.your-company.com
+
+database:
+  existingSecret: vijil-db-credentials
+
+opensearch:
+  existingSecret: vijil-opensearch-credentials
+
+storage:
+  existingSecret: vijil-s3-credentials
+  evaluationsBucket: vijil-evaluations
+  configsBucket: vijil-configs
+  uploadsBucket: vijil-uploads
+```
+
+See [Configuration Reference](/developer-guide/enterprise/configuration) for all available options.
+
+### Step 6: Deploy
+
+```bash
+helm install vijil vijil/vijil \
+  --namespace vijil \
+  --values values.yaml
+```
+
+### Step 7: Verify Deployment
+
+Check that all pods are running:
+
+```bash
+kubectl get pods -n vijil
+```
+
+Expected output:
+```
+NAME                        READY   STATUS    RESTARTS   AGE
+diamond-7d9f8b6c4d-abcde    1/1     Running   0          2m
+diamond-7d9f8b6c4d-fghij    1/1     Running   0          2m
+dome-5c8f7a9b3e-klmno       1/1     Running   0          2m
+dome-5c8f7a9b3e-pqrst       1/1     Running   0          2m
+dome-5c8f7a9b3e-uvwxy       1/1     Running   0          2m
+console-6b7c8d9e0f-12345    1/1     Running   0          2m
+console-6b7c8d9e0f-67890    1/1     Running   0          2m
+```
+
+### Step 8: Configure Ingress
+
+Create an ingress for external access:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vijil-ingress
+  namespace: vijil
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internal
+    alb.ingress.kubernetes.io/certificate-arn: <acm-certificate-arn>
+spec:
+  rules:
+  - host: vijil.your-company.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: console
+            port:
+              number: 80
+      - path: /api
+        pathType: Prefix
+        backend:
+          service:
+            name: diamond
+            port:
+              number: 80
+      - path: /dome
+        pathType: Prefix
+        backend:
+          service:
+            name: dome
+            port:
+              number: 80
+```
+
+### Step 9: Configure DNS
+
+Create a DNS record pointing `vijil.your-company.com` to your ingress load balancer.
+
+## Verification
+
+### Test Console Access
+
+Navigate to `https://vijil.your-company.com` and verify you can log in through Auth0.
+
+### Test Evaluation
+
+Run a test evaluation from the console or using the API:
+
+```python
+from vijil import Vijil
+
+vijil = Vijil(
+    api_key="your-api-key",
+    base_url="https://vijil.your-company.com/api"
+)
+
+# Create a test evaluation
+result = vijil.evaluations.create(
+    model_hub="openai",
+    model_name="gpt-4o",
+    harnesses=["trust_score"]
+)
+```
+
+### Test Dome
+
+Verify Dome is responding:
+
+```bash
+curl -X POST https://vijil.your-company.com/dome/v1/guard \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"input": "test message"}'
+```
+
+## Troubleshooting
+
+### Pods Not Starting
+
+Check pod logs:
+```bash
+kubectl logs -n vijil <pod-name>
+```
+
+Common issues:
+- Database connection failed — verify credentials and network connectivity
+- OpenSearch connection failed — check security group rules
+- S3 access denied — verify IAM role permissions
+
+### Authentication Errors
+
+- Verify Auth0 domain and client ID in values.yaml
+- Check that callback URLs are configured in Auth0
+- Ensure Auth0 application is set to "Regular Web Application"
+
+### Evaluation Failures
+
+- Verify your agents are accessible from the Vijil namespace
+- Check that egress rules allow connections to your agent endpoints
+- Review Diamond logs for specific error messages
+
+## Upgrading
+
+To upgrade to a new Vijil version:
+
+```bash
+helm repo update
+helm upgrade vijil vijil/vijil \
+  --namespace vijil \
+  --values values.yaml
+```
+
+Review the [release notes](/concepts/release-notes) before upgrading for any breaking changes.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Configuration Reference" icon="gear" href="/developer-guide/enterprise/configuration">
+    All Helm values and environment variables
+  </Card>
+  <Card title="Prerequisites" icon="clipboard-check" href="/developer-guide/enterprise/prerequisites">
+    Infrastructure requirements checklist
+  </Card>
+</CardGroup>

--- a/developer-guide/evaluate/cloud-providers.mdx
+++ b/developer-guide/evaluate/cloud-providers.mdx
@@ -1,0 +1,327 @@
+---
+title: 'Cloud Provider Integrations'
+description: 'Evaluate agents hosted on major cloud platforms.'
+---
+
+Vijil supports direct evaluation of agents and models hosted on major cloud platforms. This guide covers configuration for each supported provider.
+
+## Supported Providers
+
+| Provider | Hub ID | Supported Targets |
+|----------|--------|-------------------|
+| OpenAI | `openai` | GPT-4o, GPT-4, GPT-3.5 |
+| Anthropic | `anthropic` | Claude 3 family |
+| AWS Bedrock | `bedrock` / `bedrockAgents` | Foundation models, Bedrock Agents |
+| Google Vertex AI | `vertex` | Gemini family |
+| DigitalOcean | `digitalocean` | GenAI Platform agents |
+| Custom | `custom` | Any OpenAI-compatible endpoint |
+
+## OpenAI
+
+### Store Credentials
+
+```python
+from vijil import Vijil
+
+vijil = Vijil()
+
+vijil.api_keys.create(
+    name="openai-key",
+    model_hub="openai",
+    key="sk-..."  # Your OpenAI API key
+)
+```
+
+### Run Evaluation
+
+```python
+evaluation = vijil.evaluations.create(
+    model_hub="openai",
+    model_name="gpt-4o",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+```
+
+### Supported Models
+
+| Model | Recommended For |
+|-------|-----------------|
+| `gpt-4o` | Production agents |
+| `gpt-4-turbo` | Complex reasoning |
+| `gpt-4` | General use |
+| `gpt-3.5-turbo` | Cost-effective testing |
+
+## Anthropic
+
+### Store Credentials
+
+```python
+vijil.api_keys.create(
+    name="anthropic-key",
+    model_hub="anthropic",
+    key="sk-ant-..."  # Your Anthropic API key
+)
+```
+
+### Run Evaluation
+
+```python
+evaluation = vijil.evaluations.create(
+    model_hub="anthropic",
+    model_name="claude-3-sonnet-20240229",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+```
+
+### Supported Models
+
+| Model | Recommended For |
+|-------|-----------------|
+| `claude-3-opus-*` | Complex analysis |
+| `claude-3-sonnet-*` | Balanced performance |
+| `claude-3-haiku-*` | Fast, cost-effective |
+
+## AWS Bedrock
+
+Bedrock supports both foundation models and custom Bedrock Agents.
+
+### Foundation Models
+
+```python
+vijil.api_keys.create(
+    name="bedrock-key",
+    model_hub="bedrock",
+    hub_config={
+        "region": "us-east-1",
+        "access_key": "AKIA...",
+        "secret_access_key": "..."
+    }
+)
+
+# Run evaluation
+evaluation = vijil.evaluations.create(
+    model_hub="bedrock",
+    model_name="us.amazon.nova-lite-v1:0",  # Prepend "us." to model ID
+    harnesses=["trust_score"]
+)
+```
+
+<Note>
+For Bedrock foundation models, prepend `us.` to the model ID from [AWS's supported models list](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).
+</Note>
+
+### Bedrock Agents
+
+```python
+vijil.api_keys.create(
+    name="bedrock-agent-key",
+    model_hub="bedrockAgents",
+    hub_config={
+        "agent_id": "your-agent-id",
+        "agent_alias_id": "your-alias-id",
+        "region": "us-east-1",
+        "access_key": "AKIA...",
+        "secret_access_key": "..."
+    },
+    rate_limit_per_interval=60,
+    rate_limit_interval=60
+)
+
+# Register the agent
+vijil.agents.create(
+    name="my-bedrock-agent",
+    model_hub="bedrockAgents",
+    api_key_name="bedrock-agent-key"
+)
+
+# Run evaluation
+evaluation = vijil.evaluations.create(
+    agent_id="agent-id-from-registration",
+    harnesses=["trust_score"]
+)
+```
+
+## Google Vertex AI
+
+### Get Credentials
+
+First, authenticate with Google Cloud:
+
+```bash
+gcloud auth application-default login
+```
+
+Then retrieve the credentials from `~/.config/gcloud/application_default_credentials.json`:
+
+```json
+{
+  "client_id": "XXX.apps.googleusercontent.com",
+  "client_secret": "d-FLXXX",
+  "quota_project_id": "your-project-id",
+  "refresh_token": "xxx-123"
+}
+```
+
+### Store Credentials
+
+```python
+vijil.api_keys.create(
+    name="vertex-key",
+    model_hub="vertex",
+    hub_config={
+        "region": "us-central1",
+        "project_id": "your-project-id",
+        "client_id": "XXX.apps.googleusercontent.com",
+        "client_secret": "d-FLXXX",
+        "refresh_token": "xxx-123"
+    },
+    rate_limit_per_interval=120,
+    rate_limit_interval=60
+)
+```
+
+### Run Evaluation
+
+```python
+evaluation = vijil.evaluations.create(
+    model_hub="vertex",
+    model_name="google/gemini-1.5-flash-001",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+```
+
+### Supported Models
+
+| Model | Description |
+|-------|-------------|
+| `google/gemini-1.5-pro-*` | Most capable |
+| `google/gemini-1.5-flash-*` | Fast and efficient |
+| `google/gemini-1.0-pro-*` | Previous generation |
+
+## DigitalOcean
+
+### Get Agent Credentials
+
+Follow [DigitalOcean's guide](https://docs.digitalocean.com/products/genai-platform/how-to/manage-ai-agent/use-agent/) to get your `agent_id` and `agent_key`.
+
+### Store Credentials
+
+```python
+vijil.api_keys.create(
+    name="digitalocean-key",
+    model_hub="digitalocean",
+    hub_config={
+        "agent_id": "abc-xyz",
+        "agent_key": "xyz-123"
+    },
+    rate_limit_per_interval=60,
+    rate_limit_interval=60
+)
+```
+
+### Run Evaluation
+
+```python
+evaluation = vijil.evaluations.create(
+    model_hub="digitalocean",
+    model_url="https://agent-xxx.ondigitalocean.app/api/v1",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+```
+
+## Custom Endpoints
+
+Evaluate any agent with an OpenAI-compatible API:
+
+### Store Credentials
+
+```python
+vijil.api_keys.create(
+    name="custom-key",
+    model_hub="custom",
+    key="your-api-key"
+)
+```
+
+### Run Evaluation
+
+```python
+evaluation = vijil.evaluations.create(
+    api_key_name="custom-key",
+    model_hub="custom",
+    model_url="https://your-endpoint.com/v1",
+    model_name="your-model-name",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+```
+
+<Note>
+For local agents not yet deployed, use [LocalAgentExecutor](/developer-guide/frameworks/custom-agents) instead.
+</Note>
+
+## Rate Limiting
+
+Control evaluation pace to avoid API throttling:
+
+```python
+vijil.api_keys.create(
+    name="my-key",
+    model_hub="openai",
+    key="sk-...",
+    rate_limit_per_interval=100,  # Max requests
+    rate_limit_interval=60         # Per 60 seconds
+)
+```
+
+### Recommended Rate Limits
+
+| Provider | Requests/min | Notes |
+|----------|--------------|-------|
+| OpenAI | 60-100 | Depends on tier |
+| Anthropic | 60-100 | Depends on tier |
+| Bedrock | 30-60 | Model-dependent |
+| Vertex AI | 60-120 | Project quotas apply |
+
+## Best Practices
+
+<Tip>
+**API Key Security**: Always store API keys through Vijil's secure vault. Never commit keys to version control.
+</Tip>
+
+### For Evaluations
+
+- Use the same model version you'll deploy to production
+- Include realistic system prompts in your agent configuration
+- Set appropriate rate limits to avoid throttling
+- Start with `_Small` harnesses during development
+
+### Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Invalid API Key" | Key is inactive or incorrect | Verify in provider's dashboard |
+| "Rate Limited" | Too many requests | Reduce rate_limit_per_interval |
+| "Model Not Found" | Invalid model name | Check provider's model list |
+| "Permission Denied" | Key lacks permissions | Check API key scope |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Execute and monitor evaluations
+  </Card>
+  <Card title="Custom Agents" icon="code" href="/developer-guide/frameworks/custom-agents">
+    Evaluate local agents
+  </Card>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Interpret evaluation results
+  </Card>
+  <Card title="Configure Protection" icon="shield" href="/developer-guide/protect/configuring-guardrails">
+    Set up Dome guardrails
+  </Card>
+</CardGroup>

--- a/developer-guide/evaluate/custom-harnesses.mdx
+++ b/developer-guide/evaluate/custom-harnesses.mdx
@@ -1,0 +1,249 @@
+---
+title: 'Custom Harnesses'
+description: 'Create targeted evaluations with custom harnesses, personas, and policies.'
+---
+
+Custom harnesses let you create evaluations tailored to your agent's specific use case. Define personas (who interacts with your agent) and policies (what rules it must follow) to generate targeted test probes.
+
+## When to Use Custom Harnesses
+
+Use custom harnesses when:
+
+- Your agent serves a specific audience (e.g., enterprise customers, healthcare patients)
+- Your agent must comply with domain-specific policies
+- Standard harnesses don't cover your use case
+- You need reproducible evaluations across agent versions
+
+## Creating a Harness
+
+A harness combines personas and policies to generate evaluation scenarios:
+
+```python
+from vijil import Vijil
+
+vijil = Vijil()
+
+harness = vijil.harnesses.create(
+    name="Customer Support Compliance",
+    description="Tests support bot for policy compliance and user safety",
+    agent_id="agent-123",
+    persona_ids=["enterprise-user", "frustrated-customer"],
+    policy_ids=["privacy-policy", "brand-guidelines"]
+)
+```
+
+### Harness Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `name` | Human-readable harness name | Yes |
+| `description` | What this harness tests | No |
+| `agent_id` | Agent to associate with | Yes |
+| `persona_ids` | List of persona IDs to include | Yes |
+| `policy_ids` | List of policy IDs to enforce | No |
+
+## Managing Personas
+
+Personas represent the types of users who interact with your agent.
+
+### Create a Persona
+
+```python
+persona = vijil.personas.create(
+    name="Enterprise Admin",
+    description="IT administrator managing company accounts",
+    traits={
+        "technical_level": "high",
+        "intent": "administrative tasks",
+        "tone": "professional"
+    }
+)
+```
+
+### List Personas
+
+```python
+personas = vijil.personas.list()
+
+for p in personas:
+    print(f"{p.get('id')}: {p.get('name')}")
+```
+
+### Persona Examples
+
+| Persona | Description | Use Case |
+|---------|-------------|----------|
+| Power User | Technically sophisticated, pushes boundaries | Security testing |
+| New User | Unfamiliar with system, needs guidance | Reliability testing |
+| Adversarial User | Attempts to misuse the system | Security/safety testing |
+| Frustrated Customer | Upset, uses strong language | Safety/moderation testing |
+
+## Managing Policies
+
+Policies define rules your agent must follow.
+
+### Create a Policy
+
+```python
+policy = vijil.policies.create(
+    name="Data Privacy Policy",
+    description="Agent must not reveal or process PII inappropriately",
+    rules=[
+        "Never ask for social security numbers",
+        "Redact credit card numbers in responses",
+        "Do not store personal health information"
+    ]
+)
+```
+
+### Policy Examples
+
+| Policy | Description | Rules |
+|--------|-------------|-------|
+| Brand Voice | Maintain consistent tone | Professional language, no slang |
+| Privacy | Protect user data | No PII collection, data minimization |
+| Compliance | Regulatory requirements | GDPR consent, HIPAA safeguards |
+| Safety | Prevent harm | No dangerous instructions, crisis escalation |
+
+## Using Custom Harnesses
+
+### Run Evaluation
+
+```python
+evaluation = vijil.evaluations.create(
+    agent_id="agent-123",
+    harness=f"custom:{harness.get('id')}"
+)
+```
+
+### Combine with Standard Harnesses
+
+```python
+evaluation = vijil.evaluations.create(
+    agent_id="agent-123",
+    harnesses=[
+        "security_Small",           # Standard security harness
+        f"custom:{harness.get('id')}"  # Your custom harness
+    ]
+)
+```
+
+## Managing Harnesses
+
+### List Harnesses
+
+```python
+harnesses = vijil.harnesses.list()
+
+for h in harnesses:
+    print(f"{h.get('id')}: {h.get('name')} ({h.get('status')})")
+```
+
+### Update a Harness
+
+```python
+updated = vijil.harnesses.update(
+    harness.get("id"),
+    persona_ids=["enterprise-user", "frustrated-customer", "new-customer"],
+    policy_ids=["privacy-policy", "brand-guidelines", "compliance-policy"]
+)
+```
+
+### Delete a Harness
+
+```python
+vijil.harnesses.delete(harness.get("id"))
+```
+
+## Example: Healthcare Agent
+
+Create a comprehensive harness for a healthcare assistant:
+
+```python
+# Create personas
+patient = vijil.personas.create(
+    name="Patient",
+    description="Person seeking health information",
+    traits={"medical_knowledge": "low", "anxiety_level": "variable"}
+)
+
+caregiver = vijil.personas.create(
+    name="Family Caregiver",
+    description="Person caring for a family member",
+    traits={"medical_knowledge": "moderate", "seeking": "guidance"}
+)
+
+# Create policies
+hipaa = vijil.policies.create(
+    name="HIPAA Compliance",
+    rules=[
+        "Never store or transmit PHI without consent",
+        "Refer to healthcare providers for diagnosis",
+        "Maintain audit trail of health-related queries"
+    ]
+)
+
+safety = vijil.policies.create(
+    name="Medical Safety",
+    rules=[
+        "Always recommend professional consultation for symptoms",
+        "Never provide dosage recommendations",
+        "Escalate crisis situations immediately"
+    ]
+)
+
+# Create harness
+healthcare_harness = vijil.harnesses.create(
+    name="Healthcare Assistant Compliance",
+    description="Tests healthcare bot for HIPAA and safety compliance",
+    agent_id="healthcare-agent-id",
+    persona_ids=[patient.get("id"), caregiver.get("id")],
+    policy_ids=[hipaa.get("id"), safety.get("id")]
+)
+
+# Run evaluation
+evaluation = vijil.evaluations.create(
+    agent_id="healthcare-agent-id",
+    harness=f"custom:{healthcare_harness.get('id')}"
+)
+```
+
+## Best Practices
+
+### Persona Design
+
+- Create diverse personas representing your actual user base
+- Include edge cases (frustrated users, technical experts, beginners)
+- Consider adversarial personas for security testing
+- Update personas as you learn from production usage
+
+### Policy Design
+
+- Keep policies specific and testable
+- Map policies to regulatory requirements where applicable
+- Include both prohibitions and requirements
+- Version policies alongside your agent
+
+### Harness Management
+
+- Name harnesses descriptively (e.g., "Q1-2024 Compliance Check")
+- Document what each harness tests
+- Create separate harnesses for different evaluation goals
+- Archive old harnesses rather than deleting for audit trail
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Execute custom harness evaluations
+  </Card>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Analyze custom harness results
+  </Card>
+  <Card title="Personas" icon="users" href="/owner-guide/simulate-environment/personas">
+    Learn more about personas
+  </Card>
+  <Card title="Policies" icon="scroll" href="/owner-guide/simulate-environment/policies">
+    Learn more about policies
+  </Card>
+</CardGroup>

--- a/developer-guide/evaluate/overview.mdx
+++ b/developer-guide/evaluate/overview.mdx
@@ -1,0 +1,143 @@
+---
+title: 'Evaluation Overview'
+description: 'Test your agent''s trustworthiness before deployment with Diamond.'
+---
+
+Your agent works in demos. Your unit tests pass. But how do you know it won't hallucinate facts, leak customer data, or comply with malicious instructions when it encounters inputs you didn't anticipate?
+
+Diamond is Vijil's evaluation platform. It sends hundreds of adversarial probes to your agent—prompt injections, jailbreak attempts, data exfiltration payloads—and measures how your agent responds. You get a quantified Trust Score and specific findings you can fix before deployment.
+
+## How Evaluation Works
+
+Diamond sends test probes to your agent and analyzes the responses:
+
+<img src="/images/evaluation-flow.svg" alt="Diamond evaluation flow showing harness, scenarios, probes, agent, detectors, and Trust Score" style={{maxWidth: '600px', margin: '2rem auto', display: 'block'}} />
+
+| Component | Purpose |
+|-----------|---------|
+| **Harness** | Collection of scenarios to run (e.g., `trust_score`, `security`) |
+| **Scenario** | Testing context with personas and policies |
+| **Probe** | Individual test case sent to your agent |
+| **Detector** | Analyzes agent responses to identify failures |
+
+## Trust Score
+
+The Trust Score is a composite metric (0.0 to 1.0) based on three pillars:
+
+| Dimension | What It Measures |
+|-----------|------------------|
+| **Reliability** | Hallucination resistance, consistency, accuracy |
+| **Security** | Prompt injection, data leakage, jailbreak resistance |
+| **Safety** | Harmful content, policy compliance, ethical behavior |
+
+Higher scores indicate more trustworthy behavior. Use scores to:
+
+- Set deployment gates (e.g., require Trust Score ≥ 0.70)
+- Compare agent versions
+- Track improvements over time
+- Identify specific vulnerabilities
+
+## Evaluation Options
+
+### Cloud-Hosted Agents
+
+Evaluate agents deployed on supported cloud platforms:
+
+```python
+from vijil import Vijil
+
+vijil = Vijil()
+evaluation = vijil.evaluations.create(
+    model_hub="openai",
+    model_name="gpt-4o",
+    harnesses=["trust_score"]
+)
+```
+
+Supported platforms: OpenAI, Anthropic, AWS Bedrock, Google Vertex AI, DigitalOcean, and any OpenAI-compatible endpoint.
+
+### Local Agents
+
+Evaluate agents running locally without deployment:
+
+```python
+local_agent = vijil.local_agents.create(
+    agent_function=my_agent,
+    input_adapter=input_adapter,
+    output_adapter=output_adapter,
+)
+
+vijil.local_agents.evaluate(
+    agent_name="my-agent",
+    agent=local_agent,
+    harnesses=["trust_score"]
+)
+```
+
+This creates a temporary authenticated tunnel (via ngrok) for Vijil to communicate with your local agent.
+
+## Available Harnesses
+
+| Harness | Description | Use Case |
+|---------|-------------|----------|
+| `trust_score` | Comprehensive evaluation across all dimensions | Pre-deployment validation |
+| `security` | Prompt injection, jailbreaks, data leakage | Security review |
+| `reliability` | Hallucination, consistency, accuracy | Quality assurance |
+| `safety` | Harmful content, ethics, policy compliance | Safety review |
+| `owasp-llm-top-10` | OWASP Top 10 for LLM Applications | Compliance |
+
+Add `_Small` suffix (e.g., `security_Small`) for faster iterations during development.
+
+## Evaluation Workflow
+
+<Steps>
+  <Step title="Choose your integration method">
+    Use cloud provider integration for deployed agents, or LocalAgentExecutor for local development
+  </Step>
+  <Step title="Select harnesses">
+    Start with `trust_score` for comprehensive coverage, or specific harnesses for targeted testing
+  </Step>
+  <Step title="Run evaluation">
+    Execute via Python client, REST API, or console
+  </Step>
+  <Step title="Analyze results">
+    Review Trust Score, dimension scores, and individual failures
+  </Step>
+  <Step title="Remediate issues">
+    Fix vulnerabilities, improve prompts, add guardrails
+  </Step>
+  <Step title="Re-evaluate">
+    Confirm fixes and track improvement
+  </Step>
+</Steps>
+
+## Rate Limiting
+
+Control the evaluation pace to avoid overwhelming your agent or hitting API limits:
+
+```python
+vijil.local_agents.evaluate(
+    agent_name="my-agent",
+    agent=local_agent,
+    harnesses=["trust_score"],
+    rate_limit=30,           # Max requests per interval
+    rate_limit_interval=1    # Interval in minutes
+)
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Execute evaluations and monitor progress
+  </Card>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Interpret scores and failures
+  </Card>
+  <Card title="Cloud Providers" icon="cloud" href="/developer-guide/evaluate/cloud-providers">
+    Configure cloud platform integrations
+  </Card>
+  <Card title="Custom Harnesses" icon="wrench" href="/developer-guide/evaluate/custom-harnesses">
+    Create targeted evaluation scenarios
+  </Card>
+</CardGroup>

--- a/developer-guide/evaluate/running-evaluations.mdx
+++ b/developer-guide/evaluate/running-evaluations.mdx
@@ -1,0 +1,266 @@
+---
+title: 'Running Evaluations'
+description: 'Execute and monitor agent evaluations programmatically.'
+---
+
+Run evaluations using the Python client to test your agent's trustworthiness. This guide covers creating, monitoring, and managing evaluations.
+
+## Creating an Evaluation
+
+### Cloud-Hosted Agents
+
+For agents deployed on supported platforms:
+
+```python
+from vijil import Vijil
+
+vijil = Vijil()
+
+evaluation = vijil.evaluations.create(
+    model_hub="openai",
+    model_name="gpt-4o",
+    harnesses=["trust_score"],
+    model_params={"temperature": 0}
+)
+
+print(f"Evaluation started: {evaluation.get('id')}")
+```
+
+### Local Agents
+
+For agents running locally (see [Custom Agents](/developer-guide/frameworks/custom-agents) for full setup):
+
+```python
+local_agent = vijil.local_agents.create(
+    agent_function=my_agent,
+    input_adapter=input_adapter,
+    output_adapter=output_adapter,
+)
+
+vijil.local_agents.evaluate(
+    agent_name="my-agent",
+    evaluation_name="Pre-deployment check",
+    agent=local_agent,
+    harnesses=["trust_score"],
+    rate_limit=30,
+    rate_limit_interval=1,
+)
+```
+
+## Evaluation Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `model_hub` | Cloud provider (openai, anthropic, bedrock, vertex, etc.) | Yes |
+| `model_name` | Model identifier | Yes |
+| `harnesses` | List of harnesses to run | Yes |
+| `model_params` | Model configuration (temperature, etc.) | No |
+| `api_key_name` | Stored API key name (for custom endpoints) | Sometimes |
+| `model_url` | Custom endpoint URL | Sometimes |
+
+## Available Harnesses
+
+| Harness | Description | Typical Duration |
+|---------|-------------|------------------|
+| `trust_score` | Comprehensive evaluation | 30-60 min |
+| `security` | Security vulnerabilities | 15-30 min |
+| `reliability` | Hallucination and consistency | 15-30 min |
+| `safety` | Harmful content and ethics | 15-30 min |
+| `owasp-llm-top-10` | OWASP LLM security risks | 20-40 min |
+
+Add `_Small` suffix for faster iterations (e.g., `security_Small`).
+
+## Monitoring Progress
+
+### Get Status
+
+```python
+status = vijil.evaluations.get_status(evaluation.get("id"))
+
+print(f"Status: {status.get('status')}")
+print(f"Progress: {status.get('progress')}%")
+print(f"Probes completed: {status.get('completed')}/{status.get('total')}")
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Waiting to start |
+| `running` | Actively processing probes |
+| `completed` | Finished successfully |
+| `failed` | Terminated with error |
+| `cancelled` | Stopped by user |
+
+### Wait for Completion
+
+```python
+from vijil.local_agents.constants import TERMINAL_STATUSES
+import time
+
+while True:
+    status = vijil.evaluations.get_status(evaluation.get("id"))
+    if status.get("status") in TERMINAL_STATUSES:
+        break
+    print(f"Progress: {status.get('progress')}%")
+    time.sleep(10)
+
+print(f"Evaluation completed with status: {status.get('status')}")
+```
+
+## Retrieving Results
+
+### Get Full Results
+
+```python
+results = vijil.evaluations.get_results(evaluation.get("id"))
+
+# Trust Score (0.0 - 1.0)
+print(f"Trust Score: {results.get('trust_score')}")
+
+# Dimension scores
+print(f"Reliability: {results.get('reliability_score')}")
+print(f"Security: {results.get('security_score')}")
+print(f"Safety: {results.get('safety_score')}")
+```
+
+### Access Failures
+
+```python
+failures = results.get("failures", [])
+
+for failure in failures:
+    print(f"""
+    Probe: {failure.get('probe_id')}
+    Category: {failure.get('category')}
+    Severity: {failure.get('severity')}
+    Reason: {failure.get('reason')}
+    """)
+```
+
+### Filter by Severity
+
+```python
+# Get critical and high severity failures
+critical_failures = [
+    f for f in failures
+    if f.get("severity") in ["critical", "high"]
+]
+
+print(f"Critical/High failures: {len(critical_failures)}")
+```
+
+## Managing Evaluations
+
+### List Evaluations
+
+```python
+evaluations = vijil.evaluations.list(limit=10)
+
+for e in evaluations:
+    print(f"{e.get('id')}: {e.get('status')} - Score: {e.get('trust_score')}")
+```
+
+### Cancel an Evaluation
+
+```python
+vijil.evaluations.cancel(evaluation.get("id"))
+```
+
+### Delete an Evaluation
+
+```python
+vijil.evaluations.delete(evaluation.get("id"))
+```
+
+## Export Results
+
+### To JSON
+
+```python
+import json
+
+results = vijil.evaluations.get_results(evaluation.get("id"))
+
+with open("results.json", "w") as f:
+    json.dump(results, f, indent=2)
+```
+
+### To CSV
+
+```python
+import csv
+
+failures = results.get("failures", [])
+
+with open("failures.csv", "w", newline="") as f:
+    writer = csv.DictWriter(f, fieldnames=["probe_id", "category", "severity", "reason"])
+    writer.writeheader()
+    for failure in failures:
+        writer.writerow({
+            "probe_id": failure.get("probe_id"),
+            "category": failure.get("category"),
+            "severity": failure.get("severity"),
+            "reason": failure.get("reason")
+        })
+```
+
+## Compare Evaluations
+
+Track improvement across agent versions:
+
+```python
+results_v1 = vijil.evaluations.get_results("eval-v1-id")
+results_v2 = vijil.evaluations.get_results("eval-v2-id")
+
+score_change = results_v2.get("trust_score") - results_v1.get("trust_score")
+print(f"Trust Score change: {score_change:+.2f}")
+
+# Compare failure counts
+v1_failures = len(results_v1.get("failures", []))
+v2_failures = len(results_v2.get("failures", []))
+print(f"Failures: {v1_failures} → {v2_failures} ({v2_failures - v1_failures:+d})")
+```
+
+## Error Handling
+
+```python
+from vijil.exceptions import VijilError
+
+try:
+    evaluation = vijil.evaluations.create(
+        model_hub="openai",
+        model_name="gpt-4o",
+        harnesses=["trust_score"]
+    )
+except VijilError as e:
+    print(f"Error: {e.message}")
+    if hasattr(e, "retry_after"):
+        print(f"Retry after: {e.retry_after}s")
+```
+
+Common errors:
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Agent not found | Invalid agent_id | Verify agent exists |
+| Rate limited | Too many requests | Wait and retry |
+| Invalid API key | Missing or incorrect key | Check stored credentials |
+| Harness not found | Invalid harness name | Use valid harness ID |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Deep dive into scores and failures
+  </Card>
+  <Card title="Custom Harnesses" icon="wrench" href="/developer-guide/evaluate/custom-harnesses">
+    Create targeted evaluations
+  </Card>
+  <Card title="CI/CD Integration" icon="rotate" href="/developer-guide/cicd/overview">
+    Automate evaluations in pipelines
+  </Card>
+  <Card title="Cloud Providers" icon="cloud" href="/developer-guide/evaluate/cloud-providers">
+    Configure provider integrations
+  </Card>
+</CardGroup>

--- a/developer-guide/evaluate/understanding-results.mdx
+++ b/developer-guide/evaluate/understanding-results.mdx
@@ -1,0 +1,292 @@
+---
+title: 'Understanding Results'
+description: 'Interpret evaluation scores, analyze failures, and plan remediation.'
+---
+
+Evaluation results tell you how trustworthy your agent is and where it needs improvement. This guide explains how to interpret scores, analyze failures, and prioritize fixes.
+
+## Trust Score
+
+The Trust Score is a composite metric (0.0 to 1.0) summarizing your agent's overall trustworthiness:
+
+| Score Range | Interpretation |
+|-------------|----------------|
+| 0.85 - 1.0 | Excellent - ready for high-stakes use |
+| 0.70 - 0.84 | Good - suitable for most production use |
+| 0.50 - 0.69 | Fair - needs improvement before deployment |
+| < 0.50 | Poor - significant vulnerabilities present |
+
+The Trust Score is calculated from three dimension scores, weighted by severity of detected issues.
+
+## Dimension Scores
+
+### Reliability
+
+Measures how accurately and consistently your agent responds:
+
+| Category | What's Tested |
+|----------|---------------|
+| Hallucination | Does the agent invent facts? |
+| Consistency | Are responses consistent across similar inputs? |
+| Accuracy | Are factual claims correct? |
+| Coherence | Are responses logically structured? |
+
+**Common failures:**
+- Fabricating citations or statistics
+- Contradicting itself within a conversation
+- Providing outdated information as current
+
+### Security
+
+Measures resistance to adversarial attacks:
+
+| Category | What's Tested |
+|----------|---------------|
+| Prompt Injection | Can attackers override instructions? |
+| Jailbreak | Can safety guidelines be bypassed? |
+| Data Leakage | Does the agent reveal sensitive information? |
+| Encoding Attacks | Can obfuscation bypass filters? |
+
+**Common failures:**
+- Following injected instructions in user content
+- Revealing system prompts when asked
+- Generating content after "ignore previous instructions"
+
+### Safety
+
+Measures adherence to ethical guidelines and policies:
+
+| Category | What's Tested |
+|----------|---------------|
+| Harmful Content | Does it generate dangerous information? |
+| Bias | Are responses fair and unbiased? |
+| Policy Compliance | Does it follow usage policies? |
+| Ethics | Does it respect ethical boundaries? |
+
+**Common failures:**
+- Providing instructions for illegal activities
+- Exhibiting demographic bias
+- Generating NSFW content
+
+## Failure Severity Levels
+
+Each failure is assigned a severity level:
+
+| Severity | Impact | Examples |
+|----------|--------|----------|
+| **Critical** (S1) | Immediate risk | Prompt injection success, PII leakage |
+| **High** (S2) | Significant concern | Jailbreak bypass, harmful content |
+| **Medium** (S3) | Moderate issue | Minor hallucination, bias indication |
+| **Low** (S4) | Minor finding | Consistency variance, edge cases |
+
+Use severity to prioritize remediation:
+
+```python
+results = vijil.evaluations.get_results(evaluation_id)
+failures = results.get("failures", [])
+
+# Group by severity
+by_severity = {}
+for f in failures:
+    sev = f.get("severity", "unknown")
+    by_severity.setdefault(sev, []).append(f)
+
+print("Failure counts by severity:")
+for sev in ["critical", "high", "medium", "low"]:
+    count = len(by_severity.get(sev, []))
+    print(f"  {sev.title()}: {count}")
+```
+
+## Analyzing Failures
+
+### Failure Structure
+
+Each failure contains:
+
+```python
+{
+    "probe_id": "security-prompt-injection-001",
+    "category": "security",
+    "subcategory": "prompt_injection",
+    "severity": "critical",
+    "input_text": "The test input sent to your agent",
+    "output_text": "Your agent's response",
+    "reason": "Agent followed injected instructions",
+    "detector": "prompt-injection-classifier",
+    "confidence": 0.95
+}
+```
+
+### Grouping Failures
+
+Identify patterns by grouping failures:
+
+```python
+# By category
+by_category = {}
+for f in failures:
+    cat = f.get("category")
+    by_category.setdefault(cat, []).append(f)
+
+for cat, items in by_category.items():
+    print(f"{cat}: {len(items)} failures")
+
+# By subcategory for deeper analysis
+security_failures = by_category.get("security", [])
+by_subcategory = {}
+for f in security_failures:
+    subcat = f.get("subcategory")
+    by_subcategory.setdefault(subcat, []).append(f)
+```
+
+### Examining Specific Failures
+
+```python
+# Find the most severe failures
+critical = [f for f in failures if f.get("severity") == "critical"]
+
+for failure in critical[:5]:
+    print(f"""
+    ─────────────────────────────────────
+    Probe: {failure.get('probe_id')}
+    Severity: {failure.get('severity')}
+
+    Input: {failure.get('input_text')[:200]}...
+
+    Output: {failure.get('output_text')[:200]}...
+
+    Reason: {failure.get('reason')}
+    ─────────────────────────────────────
+    """)
+```
+
+## Remediation Strategies
+
+### For Security Failures
+
+| Failure Type | Remediation |
+|--------------|-------------|
+| Prompt injection | Add input guardrails with injection detection |
+| Jailbreak | Strengthen system prompt, add output guards |
+| Data leakage | Never include secrets in prompts |
+| Encoding attacks | Use encoding detection guards |
+
+### For Reliability Failures
+
+| Failure Type | Remediation |
+|--------------|-------------|
+| Hallucination | Add retrieval augmentation, constrain responses |
+| Inconsistency | Lower temperature, add few-shot examples |
+| Inaccuracy | Update knowledge, add fact-checking |
+
+### For Safety Failures
+
+| Failure Type | Remediation |
+|--------------|-------------|
+| Harmful content | Add content moderation guards |
+| Bias | Audit training data, add fairness testing |
+| Policy violation | Explicit policy in system prompt |
+
+## Deployment Gates
+
+Use results to enforce deployment criteria:
+
+```python
+def check_deployment_gate(results, gate_config):
+    """Check if evaluation results meet deployment criteria."""
+    issues = []
+
+    # Check Trust Score
+    trust_score = results.get("trust_score", 0)
+    if trust_score < gate_config["min_trust_score"]:
+        issues.append(f"Trust Score {trust_score:.2f} < {gate_config['min_trust_score']}")
+
+    # Check dimension scores
+    for dim in ["reliability", "security", "safety"]:
+        score = results.get(f"{dim}_score", 0)
+        min_score = gate_config.get(f"min_{dim}", 0)
+        if score < min_score:
+            issues.append(f"{dim.title()} {score:.2f} < {min_score}")
+
+    # Check critical failures
+    failures = results.get("failures", [])
+    critical_count = sum(1 for f in failures if f.get("severity") == "critical")
+    if critical_count > gate_config.get("max_critical", 0):
+        issues.append(f"Critical failures: {critical_count}")
+
+    return len(issues) == 0, issues
+
+# Example gate configuration
+gate = {
+    "min_trust_score": 0.70,
+    "min_security": 0.75,
+    "min_reliability": 0.65,
+    "min_safety": 0.70,
+    "max_critical": 0
+}
+
+passed, issues = check_deployment_gate(results, gate)
+if passed:
+    print("Ready for deployment")
+else:
+    print("Deployment blocked:")
+    for issue in issues:
+        print(f"  - {issue}")
+```
+
+## Tracking Progress
+
+Compare evaluations over time to track improvement:
+
+```python
+def compare_evaluations(old_results, new_results):
+    """Compare two evaluation results."""
+    comparison = {
+        "trust_score": {
+            "old": old_results.get("trust_score"),
+            "new": new_results.get("trust_score"),
+            "change": new_results.get("trust_score", 0) - old_results.get("trust_score", 0)
+        }
+    }
+
+    for dim in ["reliability", "security", "safety"]:
+        key = f"{dim}_score"
+        comparison[dim] = {
+            "old": old_results.get(key),
+            "new": new_results.get(key),
+            "change": new_results.get(key, 0) - old_results.get(key, 0)
+        }
+
+    # Compare failure counts
+    old_failures = len(old_results.get("failures", []))
+    new_failures = len(new_results.get("failures", []))
+    comparison["failures"] = {
+        "old": old_failures,
+        "new": new_failures,
+        "change": new_failures - old_failures
+    }
+
+    return comparison
+
+# Print comparison
+comp = compare_evaluations(results_v1, results_v2)
+print(f"Trust Score: {comp['trust_score']['old']:.2f} → {comp['trust_score']['new']:.2f} ({comp['trust_score']['change']:+.2f})")
+print(f"Failures: {comp['failures']['old']} → {comp['failures']['new']} ({comp['failures']['change']:+d})")
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Execute and monitor evaluations
+  </Card>
+  <Card title="Custom Harnesses" icon="wrench" href="/developer-guide/evaluate/custom-harnesses">
+    Create targeted test scenarios
+  </Card>
+  <Card title="Configuring Guardrails" icon="shield" href="/developer-guide/protect/configuring-guardrails">
+    Add runtime protection
+  </Card>
+  <Card title="Operational Readiness" icon="clipboard-check" href="/owner-guide/audit-agent-behavior/operational-readiness">
+    Define deployment gates
+  </Card>
+</CardGroup>

--- a/developer-guide/frameworks/custom-agents.mdx
+++ b/developer-guide/frameworks/custom-agents.mdx
@@ -1,0 +1,425 @@
+---
+title: 'Custom Python Agents'
+description: 'Evaluate and protect any Python agent with Vijil Diamond and Dome.'
+---
+
+Not using LangChain or Google ADK? Vijil works with any Python function that processes text. Whether you're calling OpenAI directly, using a custom orchestration layer, or wrapping a fine-tuned model, you can evaluate and protect your agent the same way.
+
+This guide shows you how to wrap your custom agent function for evaluation, then add runtime guardrails to intercept attacks in production.
+
+## Overview
+
+Vijil works with any Python function that takes a string and returns a string. The `LocalAgentExecutor` wraps your agent with adapters to translate between Vijil's API format and your agent's interface.
+
+| Stage | Product | Integration |
+|-------|---------|-------------|
+| **Development** | Diamond | `LocalAgentExecutor` wraps any async function |
+| **Production** | Dome | Wrap your agent function with guardrail calls |
+
+## Part 1: Evaluate Your Custom Agent
+
+Test your agent's reliability, security, and safety before deployment.
+
+### Prerequisites
+
+- Vijil API key ([get one here](https://console.vijil.ai))
+- ngrok account for local agent tunneling (free tier works)
+- Any async Python function that processes text
+
+```bash
+pip install vijil
+export VIJIL_API_KEY=your-api-key
+export NGROK_AUTHTOKEN=your-ngrok-token
+```
+
+<Warning>
+Due to how Jupyter handles event loops, run evaluation code in a `.py` script rather than a notebook.
+</Warning>
+
+### Create Input/Output Adapters
+
+Vijil communicates using OpenAI-compatible chat completion messages. Create adapters to translate between this format and your agent's interface:
+
+```python
+from vijil.local_agents.models import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionChoice,
+    ChatMessage,
+)
+
+def input_adapter(request: ChatCompletionRequest) -> str:
+    """Extract the prompt from Vijil's request format."""
+    # For simple agents, take the last message content
+    return request.messages[-1]["content"]
+
+def output_adapter(agent_output: str) -> ChatCompletionResponse:
+    """Wrap your agent's response in Vijil's expected format."""
+    message = ChatMessage(
+        role="assistant",
+        content=agent_output,
+        tool_calls=None,
+        retrieval_context=None
+    )
+    choice = ChatCompletionChoice(
+        index=0,
+        message=message,
+        finish_reason="stop"
+    )
+    return ChatCompletionResponse(
+        model="custom-agent",
+        choices=[choice],
+        usage=None
+    )
+```
+
+### Adapter Patterns
+
+Different agents need different adapter strategies:
+
+**Simple text-in, text-out:**
+```python
+def input_adapter(request: ChatCompletionRequest) -> str:
+    return request.messages[-1]["content"]
+```
+
+**Agent with system prompt:**
+```python
+def input_adapter(request: ChatCompletionRequest) -> dict:
+    system = ""
+    user = ""
+    for msg in request.messages:
+        if msg.get("role") == "system":
+            system = msg.get("content", "")
+        elif msg.get("role") == "user":
+            user = msg.get("content", "")
+    return {"system": system, "user": user}
+```
+
+**Agent with conversation history:**
+```python
+def input_adapter(request: ChatCompletionRequest) -> list:
+    return [
+        {"role": m.get("role"), "content": m.get("content")}
+        for m in request.messages
+    ]
+```
+
+**Agent returning structured data:**
+```python
+def output_adapter(agent_output: dict) -> ChatCompletionResponse:
+    # Extract the text response from your agent's structured output
+    text = agent_output.get("response", str(agent_output))
+    message = ChatMessage(
+        role="assistant",
+        content=text,
+        tool_calls=None,
+        retrieval_context=None
+    )
+    return ChatCompletionResponse(
+        model="custom-agent",
+        choices=[ChatCompletionChoice(index=0, message=message, finish_reason="stop")],
+        usage=None
+    )
+```
+
+### Run an Evaluation
+
+Create the executor and run your evaluation:
+
+```python
+import os
+from vijil import Vijil
+
+# Your custom agent function (must be async)
+async def my_agent(prompt: str) -> str:
+    # Your agent logic here
+    return f"Response to: {prompt}"
+
+# Create client and executor
+vijil = Vijil(api_key=os.getenv("VIJIL_API_KEY"))
+
+local_agent = vijil.local_agents.create(
+    agent_function=my_agent,
+    input_adapter=input_adapter,
+    output_adapter=output_adapter,
+)
+
+# Run the evaluation
+vijil.local_agents.evaluate(
+    agent_name="my-custom-agent",
+    evaluation_name="Trust Score Evaluation",
+    agent=local_agent,
+    harnesses=["trust_score"],  # Or specific harnesses
+    rate_limit=30,
+    rate_limit_interval=1,
+)
+```
+
+The evaluation runs automatically, showing live progress. Press `Ctrl+C` to cancel if needed.
+
+### Available Harnesses
+
+| Harness | Tests |
+|---------|-------|
+| `trust_score` | Comprehensive reliability, security, and safety |
+| `security` | Prompt injection, data leakage, jailbreaks |
+| `reliability` | Hallucinations, consistency, accuracy |
+| `safety` | Harmful content, policy compliance |
+| `ethics` | Bias, fairness, ethical behavior |
+
+Use `_Small` suffix (e.g., `security_Small`) for faster iterations during development.
+
+### Advanced: Manual Server Management
+
+For power users who need direct control over the evaluation server:
+
+```python
+from vijil.local_agents.constants import TERMINAL_STATUSES
+import time
+
+# Register agent and start server
+server, api_key_name = vijil.local_agents.register(
+    agent_name="my-agent",
+    evaluator=local_agent,
+    rate_limit=30,
+    rate_limit_interval=10,
+)
+
+# Create evaluation using the registered endpoint
+evaluation = vijil.evaluations.create(
+    model_hub="custom",
+    model_name="local-agent",
+    name="Manual evaluation",
+    api_key_name=api_key_name,
+    model_url=f"{server.url}/v1",
+    harnesses=["trust_score"],
+)
+
+# Wait for completion
+while True:
+    status = vijil.evaluations.get_status(evaluation.get("id")).get("status")
+    if status in TERMINAL_STATUSES:
+        break
+    time.sleep(5)
+
+# Clean up
+vijil.agents.deregister(server, api_key_name)
+```
+
+## Part 2: Protect Your Custom Agent
+
+Add Dome guardrails to filter malicious inputs and unsafe outputs at runtime.
+
+### Install Dome
+
+```bash
+pip install vijil-dome
+```
+
+### Basic Protection Pattern
+
+Wrap your agent function with guardrail calls:
+
+```python
+from vijil_dome import Dome
+
+# Create Dome instance with default guards
+dome = Dome()
+input_guardrail, output_guardrail = dome.get_guardrails()
+
+async def protected_agent(prompt: str) -> str:
+    # Check input
+    input_result = await input_guardrail.aguard(prompt)
+    if input_result.flagged:
+        return "I can't process that request."
+
+    # Run your agent
+    response = await my_agent(prompt)
+
+    # Check output
+    output_result = await output_guardrail.aguard(response)
+    if output_result.flagged:
+        return "I can't provide that response."
+
+    return response
+```
+
+### Custom Guard Configuration
+
+Configure specific guards for your use case:
+
+```python
+config = {
+    "input-guards": ["security-guard"],
+    "output-guards": ["privacy-guard", "moderation-guard"],
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-deberta-v3-base", "encoding-heuristics"]
+    },
+    "privacy-guard": {
+        "type": "privacy",
+        "methods": ["privacy-presidio"]
+    },
+    "moderation-guard": {
+        "type": "moderation",
+        "methods": ["moderation-flashtext"]
+    }
+}
+
+dome = Dome(config)
+input_guardrail, output_guardrail = dome.get_guardrails()
+```
+
+### Synchronous Usage
+
+For non-async code, use the synchronous guard method:
+
+```python
+def protected_agent_sync(prompt: str) -> str:
+    # Check input
+    input_result = input_guardrail.guard(prompt)
+    if input_result.flagged:
+        return "I can't process that request."
+
+    # Run your agent
+    response = my_agent_sync(prompt)
+
+    # Check output
+    output_result = output_guardrail.guard(response)
+    if output_result.flagged:
+        return "I can't provide that response."
+
+    return response
+```
+
+### Handling Guard Results
+
+The guard result provides detailed information about why content was flagged:
+
+```python
+result = await input_guardrail.aguard(prompt)
+
+if result.flagged:
+    print(f"Blocked by: {result.detector_name}")
+    print(f"Confidence: {result.confidence}")
+    print(f"Details: {result.details}")
+```
+
+## Evaluate Hosted Agents
+
+If your agent is already deployed with an OpenAI-compatible API, evaluate it directly without `LocalAgentExecutor`:
+
+```python
+# Store your API key first via console.vijil.ai or:
+vijil.api_keys.create(
+    name="my-hosted-agent-key",
+    hub="custom",
+    key="your-agent-api-key"
+)
+
+# Run evaluation against your endpoint
+vijil.evaluations.create(
+    api_key_name="my-hosted-agent-key",
+    model_hub="custom",
+    model_url="https://your-agent-endpoint.com/v1",
+    model_name="your-model-name",
+    harnesses=["trust_score"],
+)
+```
+
+## Complete Example
+
+Here's a full example combining evaluation and protection:
+
+```python
+import os
+from vijil import Vijil
+from vijil_dome import Dome
+from vijil.local_agents.models import (
+    ChatCompletionRequest, ChatCompletionResponse,
+    ChatCompletionChoice, ChatMessage,
+)
+
+# === STEP 1: Define your agent ===
+async def my_agent(prompt: str) -> str:
+    """Your custom agent logic."""
+    # This is where your actual agent code goes
+    # For example: calling an LLM, RAG pipeline, etc.
+    return f"Processed: {prompt}"
+
+# === STEP 2: Create adapters for evaluation ===
+def input_adapter(req: ChatCompletionRequest) -> str:
+    return req.messages[-1]["content"]
+
+def output_adapter(output: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="custom-agent",
+        choices=[ChatCompletionChoice(
+            index=0,
+            message=ChatMessage(role="assistant", content=output),
+            finish_reason="stop"
+        )]
+    )
+
+# === STEP 3: Evaluate ===
+if __name__ == "__main__":
+    vijil = Vijil(api_key=os.getenv("VIJIL_API_KEY"))
+
+    local_agent = vijil.local_agents.create(
+        agent_function=my_agent,
+        input_adapter=input_adapter,
+        output_adapter=output_adapter,
+    )
+
+    # Run evaluation (comment out after passing)
+    vijil.local_agents.evaluate(
+        agent_name="custom-agent",
+        evaluation_name="Pre-deployment check",
+        agent=local_agent,
+        harnesses=["trust_score"],
+        rate_limit=30,
+        rate_limit_interval=1,
+    )
+
+# === STEP 4: Protect for production ===
+dome = Dome()
+input_guardrail, output_guardrail = dome.get_guardrails()
+
+async def protected_agent(prompt: str) -> str:
+    """Production-ready agent with guardrails."""
+    # Check input
+    input_result = await input_guardrail.aguard(prompt)
+    if input_result.flagged:
+        return "I can't process that request."
+
+    # Run agent
+    response = await my_agent(prompt)
+
+    # Check output
+    output_result = await output_guardrail.aguard(response)
+    if output_result.flagged:
+        return "I can't provide that response."
+
+    return response
+
+# Deploy protected_agent in production
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Detailed evaluation options and result analysis
+  </Card>
+  <Card title="Configuring Guardrails" icon="sliders" href="/developer-guide/protect/configuring-guardrails">
+    Advanced guard configuration
+  </Card>
+  <Card title="Custom Detectors" icon="wrench" href="/developer-guide/protect/custom-detectors">
+    Build custom detection methods
+  </Card>
+  <Card title="CI/CD Integration" icon="rotate" href="/developer-guide/cicd/overview">
+    Automate evaluation in your pipeline
+  </Card>
+</CardGroup>

--- a/developer-guide/frameworks/google-adk.mdx
+++ b/developer-guide/frameworks/google-adk.mdx
@@ -1,0 +1,379 @@
+---
+title: 'Google ADK Agents'
+description: 'Evaluate and protect Google ADK agents with Vijil Diamond and Dome.'
+---
+
+Google ADK provides a structured framework for building agents with Gemini models. But structured doesn't mean safe—agents can still hallucinate, comply with malicious instructions, or expose sensitive data through tool calls.
+
+This guide shows you how to evaluate your ADK agent against adversarial scenarios before deployment, then add runtime guardrails using ADK's callback system to intercept attacks in production.
+
+## Overview
+
+Vijil integrates with [Google ADK](https://google.github.io/adk-docs/) at two points:
+
+| Stage | Product | Integration |
+|-------|---------|-------------|
+| **Development** | Diamond | `LocalAgentExecutor` wraps your agent for evaluation |
+| **Production** | Dome | `before_model_callback` / `after_model_callback` for filtering |
+
+## Part 1: Evaluate Your ADK Agent
+
+Test your agent's reliability, security, and safety before deployment. This works with single agents and multi-agent workflows.
+
+### Prerequisites
+
+- Vijil API key ([get one here](https://console.vijil.ai))
+- ngrok account for local agent tunneling (free tier works)
+- Your ADK agent
+
+```bash
+pip install vijil google-adk
+export VIJIL_API_KEY=your-api-key
+export NGROK_AUTHTOKEN=your-ngrok-token
+export GOOGLE_API_KEY=your-gemini-key
+```
+
+<Warning>
+Due to how Jupyter handles event loops, run evaluation code in a `.py` script rather than a notebook.
+</Warning>
+
+### Create a Runner for Your Agent
+
+ADK agents need a runner to execute queries. This example uses ADK's session management:
+
+```python
+from google.adk.sessions import InMemorySessionService
+from google.adk.runners import Runner
+from google.genai import types
+
+# Import your agent
+from my_agent import root_agent
+
+# Set up session management
+session_service = InMemorySessionService()
+APP_NAME = "My ADK Agent"
+USER_ID = "eval_user"
+SESSION_ID = "eval_session"
+
+session = session_service.create_session(
+    app_name=APP_NAME,
+    user_id=USER_ID,
+    session_id=SESSION_ID
+)
+
+# Create the runner
+runner = Runner(
+    agent=root_agent,
+    app_name=APP_NAME,
+    session_service=session_service
+)
+
+# Function to query your agent
+async def call_agent(query: str) -> str:
+    content = types.Content(role='user', parts=[types.Part(text=query)])
+    final_response = ""
+
+    async for event in runner.run_async(
+        user_id=USER_ID,
+        session_id=SESSION_ID,
+        new_message=content
+    ):
+        if event.is_final_response():
+            if event.content and event.content.parts:
+                final_response += event.content.parts[0].text
+            elif event.actions and event.actions.escalate:
+                final_response = f"Agent escalated: {event.error_message or 'No message'}"
+
+    return final_response or "No response"
+
+# Standalone agent function for Vijil
+async def run_agent(query: str) -> str:
+    return await call_agent(query)
+```
+
+### Create Input/Output Adapters
+
+Translate between Vijil's format and your agent's interface:
+
+```python
+from vijil.local_agents.models import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionChoice,
+    ChatMessage,
+)
+
+def input_adapter(request: ChatCompletionRequest) -> str:
+    """Combine all messages into a single query string."""
+    # ADK agents may not support system prompts separately
+    message_str = ""
+    for message in request.messages:
+        message_str += message.get("content", "")
+    return message_str
+
+def output_adapter(agent_output: str) -> ChatCompletionResponse:
+    """Wrap the agent's response in Vijil's expected format."""
+    message = ChatMessage(
+        role="assistant",
+        content=agent_output,
+        tool_calls=None,
+        retrieval_context=None
+    )
+    choice = ChatCompletionChoice(
+        index=0,
+        message=message,
+        finish_reason="stop"
+    )
+    return ChatCompletionResponse(
+        model="adk-agent",
+        choices=[choice],
+        usage=None
+    )
+```
+
+### Run an Evaluation
+
+```python
+import os
+from vijil import Vijil
+
+vijil = Vijil(api_key=os.getenv("VIJIL_API_KEY"))
+
+local_agent = vijil.local_agents.create(
+    agent_function=run_agent,
+    input_adapter=input_adapter,
+    output_adapter=output_adapter,
+)
+
+vijil.local_agents.evaluate(
+    agent_name="my-adk-agent",
+    evaluation_name="Security Testing",
+    agent=local_agent,
+    harnesses=["security_Small"],  # Use _Small for faster iterations
+    rate_limit=30,
+    rate_limit_interval=1,
+)
+```
+
+### Multi-Agent Workflows
+
+For multi-agent ADK setups, evaluate the entire workflow through the root agent. Vijil tests the complete system without needing access to internal agent-to-agent communication.
+
+## Part 2: Protect Your ADK Agent
+
+Add Dome guardrails using ADK's callback system.
+
+### Install Dome
+
+```bash
+pip install vijil-dome
+```
+
+### Add Callbacks to Your Agent
+
+Dome provides callback generators for ADK's `before_model_callback` and `after_model_callback`:
+
+```python
+from google.adk.agents import Agent
+from vijil_dome import Dome
+from vijil_dome.integrations.adk import (
+    generate_adk_input_callback,
+    generate_adk_output_callback
+)
+
+# Required for ADK compatibility until async callbacks are supported
+import nest_asyncio
+nest_asyncio.apply()
+
+# Create Dome instance
+dome = Dome()
+
+# Generate callback functions
+guard_input = generate_adk_input_callback(
+    dome,
+    blocked_message=None,       # Optional: custom block message
+    additional_callback=None    # Optional: chain with other callbacks
+)
+
+guard_output = generate_adk_output_callback(
+    dome,
+    blocked_message=None,
+    additional_callback=None
+)
+
+# Create your protected agent
+protected_agent = Agent(
+    model="gemini-2.0-flash-001",
+    name="protected_agent",
+    description="An ADK agent protected by Vijil Dome",
+    instruction="You are a helpful assistant.",
+    before_model_callback=guard_input,
+    after_model_callback=guard_output,
+)
+```
+
+### Custom Guard Configuration
+
+Configure specific guards for your use case:
+
+```python
+config = {
+    "input-guards": ["security-guard"],
+    "output-guards": ["privacy-guard", "moderation-guard"],
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-deberta-v3-base", "encoding-heuristics"]
+    },
+    "privacy-guard": {
+        "type": "privacy",
+        "methods": ["privacy-presidio"]
+    },
+    "moderation-guard": {
+        "type": "moderation",
+        "methods": ["moderation-flashtext"]
+    }
+}
+
+dome = Dome(config)
+
+guard_input = generate_adk_input_callback(dome)
+guard_output = generate_adk_output_callback(dome)
+```
+
+### Deploy to Cloud Run
+
+Deploy your protected ADK agent to Google Cloud Run:
+
+1. Add `vijil-dome` to your `requirements.txt`
+
+2. Deploy using gcloud CLI with increased resources:
+
+```bash
+gcloud run deploy my-agent \
+  --source . \
+  --cpu=4 \
+  --memory=8Gi \
+  --region=us-central1
+```
+
+<Warning>
+The default ADK container size (1 CPU, 512MB) is insufficient for Dome. Use at least 4 CPUs and 8Gi memory.
+</Warning>
+
+<Warning>
+Direct deployment via ADK CLI is not supported as there's no way to adjust container size. Use gcloud CLI instead.
+</Warning>
+
+### Known Limitations
+
+- **Async callbacks**: ADK doesn't yet support async model callbacks. Use `nest_asyncio` for compatibility.
+- **annoy package**: The `annoy` embeddings store is incompatible with ADK + Cloud Run. Use the default in-memory option for embeddings-based detectors if needed.
+
+## Complete Example
+
+```python
+import os
+from google.adk.agents import Agent
+from google.adk.sessions import InMemorySessionService
+from google.adk.runners import Runner
+from google.genai import types
+
+from vijil import Vijil
+from vijil_dome import Dome
+from vijil_dome.integrations.adk import (
+    generate_adk_input_callback,
+    generate_adk_output_callback
+)
+from vijil.local_agents.models import (
+    ChatCompletionRequest, ChatCompletionResponse,
+    ChatCompletionChoice, ChatMessage,
+)
+
+import nest_asyncio
+nest_asyncio.apply()
+
+# === STEP 1: Create your agent ===
+base_agent = Agent(
+    model="gemini-2.0-flash-001",
+    name="my_agent",
+    instruction="You are a helpful assistant."
+)
+
+# === STEP 2: Set up for evaluation ===
+session_service = InMemorySessionService()
+session = session_service.create_session(
+    app_name="test", user_id="user", session_id="session"
+)
+runner = Runner(agent=base_agent, app_name="test", session_service=session_service)
+
+async def run_agent(query: str) -> str:
+    content = types.Content(role='user', parts=[types.Part(text=query)])
+    response = ""
+    async for event in runner.run_async(user_id="user", session_id="session", new_message=content):
+        if event.is_final_response() and event.content:
+            response += event.content.parts[0].text
+    return response
+
+def input_adapter(req: ChatCompletionRequest) -> str:
+    return "".join(m.get("content", "") for m in req.messages)
+
+def output_adapter(output: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="adk-agent",
+        choices=[ChatCompletionChoice(
+            index=0,
+            message=ChatMessage(role="assistant", content=output),
+            finish_reason="stop"
+        )]
+    )
+
+# === STEP 3: Evaluate ===
+if __name__ == "__main__":
+    vijil = Vijil(api_key=os.getenv("VIJIL_API_KEY"))
+
+    local_agent = vijil.local_agents.create(
+        agent_function=run_agent,
+        input_adapter=input_adapter,
+        output_adapter=output_adapter,
+    )
+
+    vijil.local_agents.evaluate(
+        agent_name="adk-agent",
+        evaluation_name="Trust Score Check",
+        agent=local_agent,
+        harnesses=["trust_score"],
+        rate_limit=30,
+        rate_limit_interval=1,
+    )
+
+# === STEP 4: Protect for production ===
+dome = Dome()
+guard_input = generate_adk_input_callback(dome)
+guard_output = generate_adk_output_callback(dome)
+
+protected_agent = Agent(
+    model="gemini-2.0-flash-001",
+    name="protected_agent",
+    instruction="You are a helpful assistant.",
+    before_model_callback=guard_input,
+    after_model_callback=guard_output,
+)
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Detailed evaluation options and result analysis
+  </Card>
+  <Card title="Configuring Guardrails" icon="sliders" href="/developer-guide/protect/configuring-guardrails">
+    Advanced guard configuration
+  </Card>
+  <Card title="Custom Detectors" icon="wrench" href="/developer-guide/protect/custom-detectors">
+    Build custom detection methods
+  </Card>
+  <Card title="ADK + Dome Blog" icon="newspaper" href="https://www.vijil.ai/blog/protecting-google-adk-agents-with-vijil-dome">
+    Comprehensive multi-agent walkthrough
+  </Card>
+</CardGroup>

--- a/developer-guide/frameworks/langchain.mdx
+++ b/developer-guide/frameworks/langchain.mdx
@@ -1,0 +1,326 @@
+---
+title: 'LangChain Agents'
+description: 'Evaluate and protect LangChain agents with Vijil Diamond and Dome.'
+---
+
+LangChain makes it easy to build agents, but the same flexibility that enables powerful workflows also creates risk. A chain that retrieves documents, reasons about them, and takes actions has multiple points where it can be manipulated—through the documents it retrieves, the prompts it receives, or the tools it invokes.
+
+This guide shows you how to evaluate your LangChain agent against adversarial scenarios before deployment, then add runtime guardrails that intercept attacks your evaluations didn't anticipate.
+
+## Overview
+
+Vijil integrates with LangChain at two points:
+
+| Stage | Product | Integration |
+|-------|---------|-------------|
+| **Development** | Diamond | `LocalAgentExecutor` wraps your agent for evaluation |
+| **Production** | Dome | `GuardrailRunnable` adds input/output filtering to chains |
+
+## Part 1: Evaluate Your LangChain Agent
+
+Test your agent's reliability, security, and safety before deployment using Diamond evaluations.
+
+### Prerequisites
+
+- Vijil API key ([get one here](https://console.vijil.ai))
+- ngrok account for local agent tunneling (free tier works)
+- Your LangChain agent
+
+```bash
+pip install vijil langchain langchain-openai
+export VIJIL_API_KEY=your-api-key
+export NGROK_AUTHTOKEN=your-ngrok-token
+```
+
+<Warning>
+Due to how Jupyter handles event loops, run evaluation code in a `.py` script rather than a notebook.
+</Warning>
+
+### Create Input/Output Adapters
+
+Vijil communicates with your agent using OpenAI-compatible messages. Create adapters to translate between Vijil's format and your agent's interface:
+
+```python
+from vijil.local_agents.models import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionChoice,
+    ChatMessage,
+)
+
+def input_adapter(request: ChatCompletionRequest) -> str:
+    """Extract the user message from Vijil's request format."""
+    return request.messages[-1]["content"]
+
+def output_adapter(agent_output: str) -> ChatCompletionResponse:
+    """Wrap your agent's response in Vijil's expected format."""
+    message = ChatMessage(
+        role="assistant",
+        content=agent_output,
+        tool_calls=None,
+        retrieval_context=None
+    )
+    choice = ChatCompletionChoice(
+        index=0,
+        message=message,
+        finish_reason="stop"
+    )
+    return ChatCompletionResponse(
+        model="langchain-agent",
+        choices=[choice],
+        usage=None
+    )
+```
+
+### Run an Evaluation
+
+Wrap your agent and run a Trust Score evaluation:
+
+```python
+import os
+from vijil import Vijil
+from langchain_openai import ChatOpenAI
+from langchain.schema import SystemMessage, HumanMessage
+
+# Your LangChain agent
+chat = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+
+async def my_langchain_agent(prompt: str) -> str:
+    messages = [
+        SystemMessage(content="You are a helpful assistant."),
+        HumanMessage(content=prompt),
+    ]
+    response = await chat.ainvoke(messages)
+    return response.content
+
+# Create the Vijil client and local agent executor
+vijil = Vijil(api_key=os.getenv("VIJIL_API_KEY"))
+
+local_agent = vijil.local_agents.create(
+    agent_function=my_langchain_agent,
+    input_adapter=input_adapter,
+    output_adapter=output_adapter,
+)
+
+# Run the evaluation
+vijil.local_agents.evaluate(
+    agent_name="my-langchain-agent",
+    evaluation_name="Trust Score Evaluation",
+    agent=local_agent,
+    harnesses=["trust_score"],  # Or use specific harnesses like "security", "ethics"
+    rate_limit=30,
+    rate_limit_interval=1,
+)
+```
+
+The evaluation runs automatically, showing live progress. Press `Ctrl+C` to cancel if needed.
+
+### Available Harnesses
+
+| Harness | Tests |
+|---------|-------|
+| `trust_score` | Comprehensive reliability, security, and safety |
+| `security` | Prompt injection, data leakage, jailbreaks |
+| `reliability` | Hallucinations, consistency, accuracy |
+| `safety` | Harmful content, policy compliance |
+| `ethics` | Bias, fairness, ethical behavior |
+
+Use `_Small` suffix (e.g., `security_Small`) for faster iterations during development.
+
+## Part 2: Protect Your LangChain Agent
+
+Once your agent passes evaluation, add Dome guardrails for runtime protection.
+
+### Install Dome
+
+```bash
+pip install vijil-dome[langchain]
+```
+
+### Create Guardrails
+
+Configure input and output guards:
+
+```python
+from vijil_dome import Dome
+from vijil_dome.integrations.langchain.runnable import GuardrailRunnable
+
+# Configure guards
+config = {
+    "input-guards": ["security-guard"],
+    "output-guards": ["moderation-guard"],
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-deberta-v3-base"]
+    },
+    "moderation-guard": {
+        "type": "moderation",
+        "methods": ["moderation-flashtext"]
+    }
+}
+
+dome = Dome(config)
+input_guardrail, output_guardrail = dome.get_guardrails()
+
+# Create LangChain runnables
+input_guard = GuardrailRunnable(input_guardrail)
+output_guard = GuardrailRunnable(output_guardrail)
+```
+
+### Add Guards to Your Chain
+
+Insert guardrails into your LCEL chain:
+
+```python
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+
+prompt = ChatPromptTemplate.from_messages([
+    ('system', "You are a helpful AI assistant."),
+    ('user', '{guardrail_response_message}')
+])
+model = ChatOpenAI(model="gpt-4o-mini")
+parser = StrOutputParser()
+
+# Build the guarded chain
+guarded_chain = (
+    input_guard |
+    prompt |
+    model |
+    parser |
+    (lambda x: {"query": x}) |
+    output_guard |
+    (lambda x: x["guardrail_response_message"])
+)
+
+# Use the chain
+response = guarded_chain.invoke({"query": "What is the capital of France?"})
+```
+
+### Handle Blocked Requests
+
+Use `RunnableBranch` for custom handling when guards trigger:
+
+```python
+from langchain_core.runnables import RunnableBranch
+
+# Define the main chain (runs when input passes)
+main_chain = prompt | model | parser
+
+# Define branches based on guard results
+input_branch = RunnableBranch(
+    (lambda x: x["flagged"], lambda x: "I can't help with that request."),
+    main_chain,
+)
+
+output_branch = RunnableBranch(
+    (lambda x: x["flagged"], lambda x: "I can't provide that response."),
+    lambda x: x["guardrail_response_message"]
+)
+
+# Complete chain with branching
+chain = input_guard | input_branch | output_guard | output_branch
+```
+
+## Complete Example
+
+Here's a full example combining evaluation and protection:
+
+```python
+import os
+from vijil import Vijil
+from vijil_dome import Dome
+from vijil_dome.integrations.langchain.runnable import GuardrailRunnable
+from vijil.local_agents.models import (
+    ChatCompletionRequest, ChatCompletionResponse,
+    ChatCompletionChoice, ChatMessage,
+)
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from langchain.schema import SystemMessage, HumanMessage
+
+# === STEP 1: Define your agent ===
+chat = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
+
+async def my_agent(prompt: str) -> str:
+    messages = [
+        SystemMessage(content="You are a helpful assistant."),
+        HumanMessage(content=prompt),
+    ]
+    response = await chat.ainvoke(messages)
+    return response.content
+
+# === STEP 2: Evaluate with Diamond ===
+def input_adapter(req: ChatCompletionRequest) -> str:
+    return req.messages[-1]["content"]
+
+def output_adapter(output: str) -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        model="my-agent",
+        choices=[ChatCompletionChoice(
+            index=0,
+            message=ChatMessage(role="assistant", content=output),
+            finish_reason="stop"
+        )]
+    )
+
+if __name__ == "__main__":
+    vijil = Vijil(api_key=os.getenv("VIJIL_API_KEY"))
+
+    local_agent = vijil.local_agents.create(
+        agent_function=my_agent,
+        input_adapter=input_adapter,
+        output_adapter=output_adapter,
+    )
+
+    # Run evaluation (comment out after passing)
+    vijil.local_agents.evaluate(
+        agent_name="my-agent",
+        evaluation_name="Pre-deployment check",
+        agent=local_agent,
+        harnesses=["trust_score"],
+        rate_limit=30,
+        rate_limit_interval=1,
+    )
+
+# === STEP 3: Protect with Dome ===
+dome = Dome()  # Uses default guards
+input_guardrail, output_guardrail = dome.get_guardrails()
+
+prompt = ChatPromptTemplate.from_messages([
+    ('system', "You are a helpful assistant."),
+    ('user', '{guardrail_response_message}')
+])
+
+protected_chain = (
+    GuardrailRunnable(input_guardrail) |
+    prompt |
+    chat |
+    StrOutputParser() |
+    (lambda x: {"query": x}) |
+    GuardrailRunnable(output_guardrail) |
+    (lambda x: x["guardrail_response_message"])
+)
+
+# Deploy protected_chain in production
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Running Evaluations" icon="play" href="/developer-guide/evaluate/running-evaluations">
+    Detailed evaluation options and result analysis
+  </Card>
+  <Card title="Configuring Guardrails" icon="sliders" href="/developer-guide/protect/configuring-guardrails">
+    Advanced guard configuration
+  </Card>
+  <Card title="Custom Detectors" icon="wrench" href="/developer-guide/protect/custom-detectors">
+    Build custom detection methods
+  </Card>
+  <Card title="CI/CD Integration" icon="rotate" href="/developer-guide/cicd/overview">
+    Automate evaluation in your pipeline
+  </Card>
+</CardGroup>

--- a/developer-guide/getting-started/authentication.mdx
+++ b/developer-guide/getting-started/authentication.mdx
@@ -1,0 +1,111 @@
+---
+title: 'Authentication'
+description: 'Configure API keys for local development and CI/CD.'
+---
+
+Vijil uses API keys to authenticate requests. You'll need one key for local development, and potentially separate keys for CI/CD pipelines with different permission scopes.
+
+For automated pipelines that need to authenticate without user interaction, see [Machine-to-Machine Authentication](/developer-guide/cicd/overview#machine-to-machine-authentication) in the CI/CD guide.
+
+## Getting an API Key
+
+<Steps>
+  <Step title="Log In">
+    Go to [console.vijil.ai](https://console.vijil.ai) and log in
+  </Step>
+  <Step title="Navigate to Settings">
+    Go to **Settings > API Keys**
+  </Step>
+  <Step title="Create Key">
+    Click **Create API Key** and name it
+  </Step>
+  <Step title="Copy Key">
+    Copy the key immediately - it won't be shown again
+  </Step>
+</Steps>
+
+## Using the API Key
+
+### Environment Variable (Recommended)
+
+```bash
+export VIJIL_API_KEY="your-api-key"
+```
+
+```python
+from vijil import Client
+
+# Automatically reads from environment
+client = Client()
+```
+
+### Direct Initialization
+
+```python
+from vijil import Client
+
+client = Client(api_key="your-api-key")
+```
+
+<Warning>
+Never commit API keys to version control. Use environment variables or secrets management.
+</Warning>
+
+### Configuration File
+
+Create `~/.vijil/config.yaml`:
+
+```yaml
+api_key: your-api-key
+```
+
+## Key Permissions
+
+API keys inherit team permissions:
+
+| Scope | Capabilities |
+|-------|--------------|
+| **Full Access** | All operations |
+| **Read Only** | View only |
+| **Evaluations** | Run evaluations only |
+
+## Key Rotation
+
+Rotate keys regularly:
+
+1. Create new key
+2. Update your applications
+3. Revoke old key
+
+## Security Best Practices
+
+1. **Use environment variables** - Not hardcoded values
+2. **Rotate regularly** - Every 90 days recommended
+3. **Limit scope** - Use minimal permissions needed
+4. **Monitor usage** - Check for unauthorized access
+5. **Revoke unused keys** - Clean up old keys
+
+## Troubleshooting
+
+### "Invalid API Key"
+
+- Verify the key is correct
+- Check for extra whitespace
+- Ensure the key hasn't been revoked
+
+### "Insufficient Permissions"
+
+- Check key scope matches operation
+- Verify team membership
+- Contact admin for access
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="play" href="/developer-guide/getting-started/quickstart">
+    Run your first evaluation
+  </Card>
+  <Card title="API Reference" icon="book" href="/developer-guide/api/overview">
+    Full API documentation
+  </Card>
+</CardGroup>

--- a/developer-guide/getting-started/installation.mdx
+++ b/developer-guide/getting-started/installation.mdx
@@ -1,0 +1,97 @@
+---
+title: 'Installation'
+description: 'Install the Vijil Python client and Dome SDK.'
+---
+
+The Vijil package includes everything you need to evaluate and protect agents programmatically:
+
+- **Vijil client** — Run evaluations, manage agents, retrieve results
+- **LocalAgentExecutor** — Wrap local agent functions for evaluation without deployment
+- **Dome SDK** — Add runtime guardrails to intercept and filter agent inputs/outputs
+
+One package, one install. Choose optional extras based on your framework.
+
+## Requirements
+
+- Python 3.9+
+- pip or poetry
+
+## Install with pip
+
+```bash
+pip install vijil
+```
+
+## Install with poetry
+
+```bash
+poetry add vijil
+```
+
+## Verify Installation
+
+```python
+import vijil
+print(vijil.__version__)
+```
+
+## Quick Test
+
+```python
+from vijil import Client
+
+client = Client(api_key="your-api-key")
+
+# List your agents
+agents = client.agents.list()
+print(f"Found {len(agents)} agents")
+```
+
+## Optional Dependencies
+
+### For Dome SDK
+
+```bash
+pip install vijil[dome]
+```
+
+### For LangChain Integration
+
+```bash
+pip install vijil[langchain]
+```
+
+### For Full Development
+
+```bash
+pip install vijil[all]
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+export VIJIL_API_KEY="your-api-key"
+```
+
+### Configuration File
+
+Create `~/.vijil/config.yaml`:
+
+```yaml
+api_key: your-api-key
+base_url: https://api.vijil.ai  # default
+timeout: 30  # seconds
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Authentication" icon="key" href="/developer-guide/getting-started/authentication">
+    Configure API keys
+  </Card>
+  <Card title="Quickstart" icon="play" href="/developer-guide/getting-started/quickstart">
+    Run your first evaluation
+  </Card>
+</CardGroup>

--- a/developer-guide/getting-started/introduction.mdx
+++ b/developer-guide/getting-started/introduction.mdx
@@ -1,0 +1,100 @@
+---
+title: 'Building Trusted Agents'
+description: 'Integrate evaluation and protection into your development workflow—catch failures before they reach production.'
+---
+
+## The Problem with Testing Agents
+
+Traditional software testing catches bugs. But agents fail in ways that don't look like bugs—they hallucinate confidently, comply with requests they should refuse, and behave differently under adversarial pressure than in demos. Your unit tests pass, your integration tests pass, and then your agent leaks customer data in production.
+
+This guide shows you how to catch those failures before deployment. You'll learn to evaluate agents against adversarial scenarios, integrate trust gates into your CI/CD pipeline, and add runtime protection that blocks attacks your evaluations didn't anticipate.
+
+<Info>
+If you manage agents through a web console rather than code, see the [Agent Owner Guide](/owner-guide/getting-started/introduction). This guide focuses on programmatic integration.
+</Info>
+
+## What You Get from Vijil
+
+Vijil provides two products that work together:
+
+**Diamond** evaluates your agent by sending hundreds of adversarial probes and measuring how it responds. You get a Trust Score—a quantified measure of reliability, security, and safety—plus specific findings you can fix.
+
+**Dome** protects your agent at runtime by intercepting inputs and outputs. When Diamond identifies vulnerabilities you can't immediately fix, Dome blocks the attack patterns in production.
+
+## Three Developer Workflows
+
+Different roles use Vijil differently. This guide serves all three:
+
+<CardGroup cols={3}>
+  <Card title="Build & Test" icon="code">
+    **Individual developer**
+
+    You're building an agent and want fast feedback on whether it's trustworthy. Run evaluations locally, see results in minutes, iterate quickly.
+
+    **Start here:**
+    - [Quickstart](/developer-guide/getting-started/quickstart)
+    - [Framework Guides](/developer-guide/frameworks/langchain)
+  </Card>
+  <Card title="Automate & Gate" icon="rotate">
+    **Platform engineer**
+
+    You're integrating Vijil into CI/CD. Evaluations run on every PR, Trust Scores gate deployments, and failures block merges.
+
+    **Start here:**
+    - [CI/CD Overview](/developer-guide/cicd/overview)
+    - [GitHub Actions](/developer-guide/cicd/github-actions)
+  </Card>
+  <Card title="Protect & Audit" icon="shield">
+    **Security/compliance**
+
+    You need evidence that agents meet security requirements. Trust Reports document what was tested, and Dome provides runtime defense-in-depth.
+
+    **Start here:**
+    - [Understanding Results](/developer-guide/evaluate/understanding-results)
+    - [Protection Overview](/developer-guide/protect/overview)
+  </Card>
+</CardGroup>
+
+## What Vijil Measures
+
+Agents fail across three dimensions. Vijil tests all of them:
+
+| Dimension | What It Measures | Example Failures |
+|-----------|------------------|------------------|
+| **Reliability** | Does the agent do what it's supposed to do? | Hallucinations, task failures, inconsistent responses |
+| **Security** | Can the agent resist adversarial manipulation? | Prompt injection, data exfiltration, jailbreaks |
+| **Safety** | Does the agent stay within acceptable boundaries? | Policy violations, harmful content, unauthorized actions |
+
+Each evaluation produces a **Trust Score** (0–1) with breakdowns by dimension. The score tells you where your agent is strong, where it's vulnerable, and whether it meets your deployment threshold.
+
+## Time to First Trust Score
+
+You can get your first evaluation result in about 15 minutes:
+
+1. **Install** the Python client (30 seconds)
+2. **Authenticate** with your API key (1 minute)
+3. **Run** the quickstart evaluation (10–15 minutes depending on agent complexity)
+
+The quickstart uses your existing agent code—no modifications required. Vijil wraps your agent function, exposes it temporarily for evaluation, and tears down when complete.
+
+## Integration Points
+
+Vijil integrates with the tools you already use:
+
+| Framework | Integration |
+|-----------|-------------|
+| **LangChain / LangGraph** | `GuardrailRunnable` for chains, `LocalAgentExecutor` for evaluation |
+| **Google ADK** | Before/after callbacks for Dome, ADK Runner for evaluation |
+| **Custom Python** | Wrap any function that takes a prompt and returns a response |
+| **CI/CD** | GitHub Actions, GitLab CI, or any system that can run Python |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="play" href="/developer-guide/getting-started/quickstart">
+    Get your first Trust Score in 15 minutes
+  </Card>
+  <Card title="Installation" icon="download" href="/developer-guide/getting-started/installation">
+    Set up the Python client and Dome SDK
+  </Card>
+</CardGroup>

--- a/developer-guide/getting-started/quickstart.mdx
+++ b/developer-guide/getting-started/quickstart.mdx
@@ -1,0 +1,110 @@
+---
+title: 'Quickstart'
+description: 'Get your first Trust Score in 15 minutes.'
+---
+
+This quickstart evaluates your agent against Vijil's Trust Score harness. You'll wrap your existing agent function, run an evaluation, and see results—all in about 15 minutes.
+
+## Prerequisites
+
+- Python 3.9+
+- A Vijil API key ([get one here](https://console.vijil.ai))
+- An OpenAI API key (or another LLM provider)
+
+## Install
+
+```bash
+pip install vijil
+```
+
+## Set Credentials
+
+```bash
+export VIJIL_API_KEY="your-vijil-key"
+export OPENAI_API_KEY="your-openai-key"
+```
+
+## Evaluate Your Agent
+
+Create a file called `evaluate.py`:
+
+```python
+from vijil import Vijil
+from openai import OpenAI
+
+# Define your agent as a function
+def my_agent(prompt: str) -> str:
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prompt}
+        ]
+    )
+    return response.choices[0].message.content
+
+# Evaluate it
+vijil = Vijil()
+
+local_agent = vijil.local_agents.create(
+    agent_function=my_agent,
+    agent_name="my-first-agent"
+)
+
+vijil.local_agents.evaluate(
+    agent_name="my-first-agent",
+    harnesses=["trust_score"]
+)
+```
+
+Run it:
+
+```bash
+python evaluate.py
+```
+
+The evaluation takes 10–15 minutes. When complete, you'll see output like:
+
+```
+Trust Score: 0.82
+├── Reliability: 0.91
+├── Security: 0.74
+└── Safety: 0.85
+
+High-severity findings: 2
+Medium-severity findings: 5
+```
+
+## What Just Happened?
+
+1. **Vijil wrapped your agent** in a temporary HTTP server using ngrok
+2. **Diamond sent probes** — adversarial prompts testing for hallucinations, prompt injection, jailbreaks, and more
+3. **Detectors analyzed responses** — checking if your agent leaked data, followed malicious instructions, or violated safety policies
+4. **Results aggregated** into a Trust Score with specific findings
+
+Your agent code wasn't modified. The evaluation ran against your actual implementation.
+
+## View Detailed Results
+
+Open the [Vijil Console](https://console.vijil.ai) to see:
+- Per-probe results with the exact prompts and responses
+- Failure explanations with remediation guidance
+- Comparison with previous evaluations
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Framework Guides" icon="code" href="/developer-guide/frameworks/langchain">
+    Integrate with LangChain, Google ADK, or custom frameworks
+  </Card>
+  <Card title="Add Protection" icon="shield" href="/developer-guide/protect/overview">
+    Block attacks at runtime with Dome guardrails
+  </Card>
+  <Card title="CI/CD Integration" icon="rotate" href="/developer-guide/cicd/overview">
+    Run evaluations on every pull request
+  </Card>
+  <Card title="Understanding Results" icon="chart-bar" href="/developer-guide/evaluate/understanding-results">
+    Interpret scores and prioritize fixes
+  </Card>
+</CardGroup>

--- a/developer-guide/protect/configuring-guardrails.mdx
+++ b/developer-guide/protect/configuring-guardrails.mdx
@@ -1,0 +1,372 @@
+---
+title: 'Configuring Guardrails'
+description: 'Detailed configuration options for Dome guards and detectors.'
+---
+
+Dome's configuration system lets you precisely control which guards run, how they execute, and what detectors they use. This guide covers all configuration options.
+
+## Configuration Hierarchy
+
+Dome organizes protection in three levels:
+
+```
+Guardrail (input/output)
+    └── Guard (security, moderation, privacy)
+            └── Detector (specific detection method)
+```
+
+Each level has its own configuration options that can be customized.
+
+## Guardrail Configuration
+
+### Basic Structure
+
+```python
+config = {
+    # List of guards for each guardrail
+    "input-guards": ["security-guard", "moderation-guard"],
+    "output-guards": ["privacy-guard", "moderation-guard"],
+
+    # Guardrail-level execution settings
+    "input-early-exit": True,
+    "input-run-parallel": False,
+    "output-early-exit": True,
+    "output-run-parallel": False,
+
+    # Guard definitions (see below)
+    "security-guard": { ... },
+    "moderation-guard": { ... },
+    "privacy-guard": { ... }
+}
+```
+
+### Guardrail Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `input-guards` | List | [] | Guards to run on input |
+| `output-guards` | List | [] | Guards to run on output |
+| `input-early-exit` | Boolean | True | Stop on first input flag |
+| `input-run-parallel` | Boolean | False | Run input guards in parallel |
+| `output-early-exit` | Boolean | True | Stop on first output flag |
+| `output-run-parallel` | Boolean | False | Run output guards in parallel |
+
+### Execution Modes
+
+**Early Exit (default)**: Stops processing when the first guard flags content. Faster for rejecting clearly malicious input.
+
+```python
+config = {
+    "input-early-exit": True,  # Stop at first flag
+    "input-guards": ["security-guard", "moderation-guard"]
+}
+# If security-guard flags, moderation-guard won't run
+```
+
+**Complete Execution**: Runs all guards regardless of flags. Useful for comprehensive logging.
+
+```python
+config = {
+    "input-early-exit": False,  # Run all guards
+    "input-guards": ["security-guard", "moderation-guard"]
+}
+# Both guards always run, all flags recorded
+```
+
+**Parallel Execution**: Runs guards simultaneously for lower latency.
+
+```python
+config = {
+    "input-run-parallel": True,
+    "input-early-exit": False  # Often paired with parallel
+}
+```
+
+## Guard Configuration
+
+### Structure
+
+Each guard groups detectors of the same type:
+
+```python
+config = {
+    "input-guards": ["my-security-guard"],
+
+    "my-security-guard": {
+        "type": "security",                    # Required: guard type
+        "methods": ["prompt-injection-mbert"], # Required: detectors
+        "early-exit": True,                    # Optional
+        "run-parallel": False,                 # Optional
+        "blocked-response": "Request blocked"  # Optional
+    }
+}
+```
+
+### Guard Types
+
+| Type | Use Case | Available Detectors |
+|------|----------|---------------------|
+| `security` | Adversarial attacks | Prompt injection, encoding detection |
+| `moderation` | Harmful content | Toxicity, profanity, hate speech |
+| `privacy` | Sensitive data | PII detection, secrets |
+| `integrity` | Data quality | Format validation (experimental) |
+| `generic` | Custom logic | User-defined detectors |
+
+### Guard Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `type` | String | Required | Guard category |
+| `methods` | List | Required | Detectors to use |
+| `early-exit` | Boolean | True | Stop on first detector flag |
+| `run-parallel` | Boolean | False | Run detectors in parallel |
+| `blocked-response` | String | Default | Custom block message |
+
+## Detector Configuration
+
+### Available Detectors
+
+**Security Detectors:**
+
+| Detector | Description | Options |
+|----------|-------------|---------|
+| `prompt-injection-mbert` | Multilingual BERT model | `threshold` |
+| `prompt-injection-deberta-v3-base` | DeBERTa v3 model | `threshold` |
+| `encoding-heuristics` | Base64, Unicode tricks | None |
+| `security-embeddings` | Semantic similarity | `threshold`, `top_k` |
+| `security-llm` | LLM-based detection | `model_name` |
+
+**Moderation Detectors:**
+
+| Detector | Description | Options |
+|----------|-------------|---------|
+| `moderation-flashtext` | Fast keyword matching | `wordlist` |
+| `moderation-deberta` | Neural toxicity classifier | `threshold` |
+| `moderations-oai-api` | OpenAI Moderation API | None |
+| `moderation-llamaguard` | Llama Guard model | `threshold` |
+
+**Privacy Detectors:**
+
+| Detector | Description | Options |
+|----------|-------------|---------|
+| `privacy-presidio` | PII entity recognition | `entities`, `threshold` |
+| `detect-secrets` | Credential detection | None |
+
+### Detector-Level Configuration
+
+Configure individual detectors within a guard:
+
+```python
+config = {
+    "input-guards": ["security-guard"],
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-mbert", "security-llm"],
+
+        # Detector-specific settings
+        "prompt-injection-mbert": {
+            "threshold": 0.8  # Confidence threshold
+        },
+        "security-llm": {
+            "model_name": "gpt-4o"  # Model to use
+        }
+    }
+}
+```
+
+### Common Detector Options
+
+**Threshold**: Confidence score required to flag (0.0-1.0)
+
+```python
+"prompt-injection-mbert": {
+    "threshold": 0.9  # Higher = fewer false positives
+}
+```
+
+**Model Selection**: For LLM-based detectors
+
+```python
+"security-llm": {
+    "model_name": "gpt-4o-mini"  # Faster, cheaper
+}
+```
+
+## TOML Configuration
+
+Store configuration in a file for easier management:
+
+```toml
+# dome-config.toml
+[guardrail]
+input-guards = ["security-guard", "moderation-guard"]
+output-guards = ["privacy-guard"]
+input-early-exit = true
+input-run-parallel = false
+
+[security-guard]
+type = "security"
+methods = ["prompt-injection-deberta-v3-base", "encoding-heuristics"]
+early-exit = true
+
+[security-guard.prompt-injection-deberta-v3-base]
+threshold = 0.85
+
+[moderation-guard]
+type = "moderation"
+methods = ["moderation-flashtext", "moderation-deberta"]
+
+[privacy-guard]
+type = "privacy"
+methods = ["privacy-presidio"]
+
+[privacy-guard.privacy-presidio]
+entities = ["PERSON", "EMAIL", "PHONE_NUMBER", "CREDIT_CARD"]
+```
+
+Load from file:
+
+```python
+from vijil_dome import Dome
+
+dome = Dome("dome-config.toml")
+```
+
+<Note>
+Use lowercase `true` and `false` for booleans in TOML files.
+</Note>
+
+## Configuration Examples
+
+### Minimal Security
+
+Fast, low-latency protection:
+
+```python
+config = {
+    "input-guards": ["security-guard"],
+    "input-early-exit": True,
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-mbert"]
+    }
+}
+```
+
+### Comprehensive Protection
+
+Full coverage for sensitive applications:
+
+```python
+config = {
+    "input-guards": ["security-guard", "moderation-guard"],
+    "output-guards": ["privacy-guard", "moderation-guard"],
+    "input-early-exit": False,
+    "output-early-exit": False,
+
+    "security-guard": {
+        "type": "security",
+        "methods": [
+            "prompt-injection-deberta-v3-base",
+            "encoding-heuristics",
+            "security-embeddings"
+        ],
+        "run-parallel": True
+    },
+    "moderation-guard": {
+        "type": "moderation",
+        "methods": ["moderation-deberta", "moderations-oai-api"],
+        "run-parallel": True
+    },
+    "privacy-guard": {
+        "type": "privacy",
+        "methods": ["privacy-presidio", "detect-secrets"]
+    }
+}
+```
+
+### Privacy-Focused
+
+For healthcare, finance, or regulated industries:
+
+```python
+config = {
+    "input-guards": ["security-guard"],
+    "output-guards": ["privacy-guard"],
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-deberta-v3-base"]
+    },
+    "privacy-guard": {
+        "type": "privacy",
+        "methods": ["privacy-presidio"],
+        "privacy-presidio": {
+            "entities": [
+                "PERSON", "EMAIL", "PHONE_NUMBER",
+                "CREDIT_CARD", "US_SSN", "MEDICAL_LICENSE"
+            ],
+            "threshold": 0.7
+        }
+    }
+}
+```
+
+### Low-Latency Production
+
+Optimized for speed:
+
+```python
+config = {
+    "input-guards": ["fast-security"],
+    "output-guards": ["fast-moderation"],
+    "input-early-exit": True,
+    "output-early-exit": True,
+
+    "fast-security": {
+        "type": "security",
+        "methods": ["prompt-injection-mbert"],  # Fastest model
+        "early-exit": True
+    },
+    "fast-moderation": {
+        "type": "moderation",
+        "methods": ["moderation-flashtext"],  # Keyword-based, very fast
+        "early-exit": True
+    }
+}
+```
+
+## Loading Configuration from Console
+
+Pull configuration from your Vijil Console setup:
+
+```python
+import os
+from vijil_dome import Dome
+
+dome = Dome.create_from_vijil_agent(
+    agent_id="your-agent-id",
+    api_key=os.environ["VIJIL_API_KEY"]
+)
+```
+
+This keeps your code and configuration in sync across environments.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Using Guardrails" icon="shield" href="/developer-guide/protect/using-guardrails">
+    Runtime integration patterns
+  </Card>
+  <Card title="Custom Detectors" icon="wrench" href="/developer-guide/protect/custom-detectors">
+    Build your own detectors
+  </Card>
+  <Card title="Observability" icon="eye" href="/developer-guide/protect/observability">
+    Monitoring and tracing
+  </Card>
+  <Card title="Framework Guides" icon="code" href="/developer-guide/frameworks/langchain">
+    Framework-specific integration
+  </Card>
+</CardGroup>

--- a/developer-guide/protect/custom-detectors.mdx
+++ b/developer-guide/protect/custom-detectors.mdx
@@ -1,0 +1,376 @@
+---
+title: 'Custom Detectors'
+description: 'Build custom detection methods for Dome guardrails.'
+---
+
+Dome allows you to create custom detectors to implement domain-specific detection logic. This guide covers creating, registering, and using custom detectors.
+
+## Creating a Custom Detector
+
+Custom detectors extend the `DetectionMethod` class and implement the `detect` method:
+
+```python
+from vijil_dome.detectors import (
+    DetectionCategory,
+    DetectionResult,
+    DetectionMethod,
+    register_method,
+)
+
+# Define a unique name for your detector
+CUSTOM_DETECTOR_NAME = "custom-length-detector"
+
+# Register with a category
+@register_method(DetectionCategory.Security, CUSTOM_DETECTOR_NAME)
+class CustomLengthDetector(DetectionMethod):
+    def __init__(self, min_length=10, max_length=1000):
+        super().__init__()
+        self.min_length = min_length
+        self.max_length = max_length
+
+    async def detect(self, query_string: str) -> DetectionResult:
+        # Your detection logic
+        flagged = len(query_string) < self.min_length or len(query_string) > self.max_length
+
+        # Return (flagged: bool, metadata: dict)
+        return flagged, {
+            "type": type(self).__name__,
+            "length": len(query_string),
+            "query_string": query_string,
+            "response_string": self.blocked_response_string if flagged else query_string,
+        }
+```
+
+## Detection Categories
+
+Register your detector with one of these categories:
+
+| Category | Use Case |
+|----------|----------|
+| `DetectionCategory.Security` | Adversarial attacks, injections |
+| `DetectionCategory.Moderation` | Harmful content, toxicity |
+| `DetectionCategory.Privacy` | PII, secrets, sensitive data |
+| `DetectionCategory.Integrity` | Data quality, format validation |
+| `DetectionCategory.Generic` | Anything else |
+
+The category determines which guard types can use your detector.
+
+## Detection Result Format
+
+The `detect` method must return a tuple of `(flagged: bool, metadata: dict)`:
+
+```python
+async def detect(self, query_string: str) -> DetectionResult:
+    flagged = should_flag(query_string)
+
+    metadata = {
+        "type": type(self).__name__,           # Detector class name
+        "query_string": query_string,          # Original input
+        "response_string": safe_response,      # Output to use
+        "confidence": 0.95,                    # Optional: confidence score
+        "reason": "Detected pattern X",        # Optional: explanation
+        # Add any other metadata you need
+    }
+
+    return flagged, metadata
+```
+
+<Note>
+Always include `query_string` and `response_string` in metadata for proper guardrail operation.
+</Note>
+
+## Using Custom Detectors
+
+### Define Before Instantiation
+
+Custom detectors must be defined before creating the Dome instance:
+
+```python
+from vijil_dome.detectors import (
+    DetectionCategory, DetectionResult, DetectionMethod, register_method
+)
+from vijil_dome import Dome
+
+# Define your detector FIRST
+@register_method(DetectionCategory.Security, "custom-length-detector")
+class CustomLengthDetector(DetectionMethod):
+    def __init__(self, min_length=10, max_length=1000):
+        super().__init__()
+        self.min_length = min_length
+        self.max_length = max_length
+
+    async def detect(self, query_string: str) -> DetectionResult:
+        flagged = len(query_string) < self.min_length or len(query_string) > self.max_length
+        return flagged, {
+            "type": type(self).__name__,
+            "query_string": query_string,
+            "response_string": self.blocked_response_string if flagged else query_string,
+        }
+
+# THEN create Dome with your detector
+config = {
+    "input-guards": ["length-guard"],
+    "length-guard": {
+        "type": "security",
+        "methods": ["custom-length-detector"],
+        "custom-length-detector": {
+            "min_length": 5,
+            "max_length": 500
+        }
+    }
+}
+
+dome = Dome(config)
+```
+
+### Import from Separate File
+
+For cleaner organization, define detectors in a separate module:
+
+```python
+# custom_detectors.py
+from vijil_dome.detectors import (
+    DetectionCategory, DetectionResult, DetectionMethod, register_method
+)
+
+@register_method(DetectionCategory.Moderation, "custom-keyword-detector")
+class CustomKeywordDetector(DetectionMethod):
+    def __init__(self, keywords=None):
+        super().__init__()
+        self.keywords = keywords or ["forbidden", "blocked"]
+
+    async def detect(self, query_string: str) -> DetectionResult:
+        query_lower = query_string.lower()
+        flagged = any(kw in query_lower for kw in self.keywords)
+        return flagged, {
+            "type": type(self).__name__,
+            "query_string": query_string,
+            "response_string": self.blocked_response_string if flagged else query_string,
+        }
+```
+
+```python
+# main.py
+import custom_detectors  # Import to register detectors
+from vijil_dome import Dome
+
+config = {
+    "input-guards": ["keyword-guard"],
+    "keyword-guard": {
+        "type": "moderation",
+        "methods": ["custom-keyword-detector"],
+        "custom-keyword-detector": {
+            "keywords": ["spam", "advertisement", "promotion"]
+        }
+    }
+}
+
+dome = Dome(config)
+```
+
+<Warning>
+Import your custom detector module before creating the Dome instance. The `@register_method` decorator must run before the config is parsed.
+</Warning>
+
+## Example Detectors
+
+### Rate Limiter
+
+Track request frequency per user:
+
+```python
+import time
+from collections import defaultdict
+
+@register_method(DetectionCategory.Security, "rate-limiter")
+class RateLimiterDetector(DetectionMethod):
+    # Class-level storage (shared across instances)
+    request_times = defaultdict(list)
+
+    def __init__(self, max_requests=10, window_seconds=60, user_id_extractor=None):
+        super().__init__()
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self.user_id_extractor = user_id_extractor or (lambda x: "default")
+
+    async def detect(self, query_string: str) -> DetectionResult:
+        user_id = self.user_id_extractor(query_string)
+        now = time.time()
+
+        # Clean old requests
+        self.request_times[user_id] = [
+            t for t in self.request_times[user_id]
+            if now - t < self.window_seconds
+        ]
+
+        # Check rate
+        flagged = len(self.request_times[user_id]) >= self.max_requests
+
+        if not flagged:
+            self.request_times[user_id].append(now)
+
+        return flagged, {
+            "type": type(self).__name__,
+            "query_string": query_string,
+            "response_string": "Rate limit exceeded. Please wait." if flagged else query_string,
+            "request_count": len(self.request_times[user_id]),
+        }
+```
+
+### Regex Pattern Detector
+
+Block content matching patterns:
+
+```python
+import re
+
+@register_method(DetectionCategory.Security, "regex-detector")
+class RegexDetector(DetectionMethod):
+    def __init__(self, patterns=None):
+        super().__init__()
+        self.patterns = [re.compile(p, re.IGNORECASE) for p in (patterns or [])]
+
+    async def detect(self, query_string: str) -> DetectionResult:
+        matches = []
+        for pattern in self.patterns:
+            if pattern.search(query_string):
+                matches.append(pattern.pattern)
+
+        flagged = len(matches) > 0
+
+        return flagged, {
+            "type": type(self).__name__,
+            "query_string": query_string,
+            "response_string": self.blocked_response_string if flagged else query_string,
+            "matched_patterns": matches,
+        }
+```
+
+### External API Detector
+
+Call an external service for detection:
+
+```python
+import httpx
+
+@register_method(DetectionCategory.Moderation, "external-api-detector")
+class ExternalAPIDetector(DetectionMethod):
+    def __init__(self, api_url=None, api_key=None, threshold=0.5):
+        super().__init__()
+        self.api_url = api_url
+        self.api_key = api_key
+        self.threshold = threshold
+
+    async def detect(self, query_string: str) -> DetectionResult:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self.api_url,
+                json={"text": query_string},
+                headers={"Authorization": f"Bearer {self.api_key}"}
+            )
+            result = response.json()
+
+        score = result.get("score", 0)
+        flagged = score >= self.threshold
+
+        return flagged, {
+            "type": type(self).__name__,
+            "query_string": query_string,
+            "response_string": self.blocked_response_string if flagged else query_string,
+            "api_score": score,
+            "api_response": result,
+        }
+```
+
+### Semantic Similarity Detector
+
+Block content similar to known bad examples:
+
+```python
+from sentence_transformers import SentenceTransformer, util
+
+@register_method(DetectionCategory.Security, "semantic-blocklist")
+class SemanticBlocklistDetector(DetectionMethod):
+    def __init__(self, blocklist=None, threshold=0.8, model_name="all-MiniLM-L6-v2"):
+        super().__init__()
+        self.blocklist = blocklist or []
+        self.threshold = threshold
+        self.model = SentenceTransformer(model_name)
+        self.blocklist_embeddings = self.model.encode(self.blocklist) if self.blocklist else []
+
+    async def detect(self, query_string: str) -> DetectionResult:
+        if not self.blocklist:
+            return False, {"type": type(self).__name__, "query_string": query_string, "response_string": query_string}
+
+        query_embedding = self.model.encode(query_string)
+        similarities = util.cos_sim(query_embedding, self.blocklist_embeddings)[0]
+
+        max_similarity = float(similarities.max())
+        flagged = max_similarity >= self.threshold
+
+        return flagged, {
+            "type": type(self).__name__,
+            "query_string": query_string,
+            "response_string": self.blocked_response_string if flagged else query_string,
+            "max_similarity": max_similarity,
+        }
+```
+
+## Testing Custom Detectors
+
+Test your detector before deployment:
+
+```python
+import asyncio
+from vijil_dome import Dome
+
+# Define detector
+@register_method(DetectionCategory.Security, "test-detector")
+class TestDetector(DetectionMethod):
+    async def detect(self, query_string: str) -> DetectionResult:
+        flagged = "test" in query_string.lower()
+        return flagged, {
+            "type": type(self).__name__,
+            "query_string": query_string,
+            "response_string": "Blocked" if flagged else query_string,
+        }
+
+# Test it
+async def test():
+    dome = Dome({
+        "input-guards": ["test-guard"],
+        "test-guard": {
+            "type": "security",
+            "methods": ["test-detector"]
+        }
+    })
+
+    # Should be blocked
+    result = await dome.async_guard_input("This is a test message")
+    assert not result.is_safe()
+
+    # Should pass
+    result = await dome.async_guard_input("Hello world")
+    assert result.is_safe()
+
+    print("All tests passed!")
+
+asyncio.run(test())
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Configuring Guardrails" icon="sliders" href="/developer-guide/protect/configuring-guardrails">
+    Use custom detectors in configurations
+  </Card>
+  <Card title="Using Guardrails" icon="shield" href="/developer-guide/protect/using-guardrails">
+    Runtime integration patterns
+  </Card>
+  <Card title="Observability" icon="eye" href="/developer-guide/protect/observability">
+    Monitor custom detector performance
+  </Card>
+  <Card title="Protection Overview" icon="book" href="/developer-guide/protect/overview">
+    Built-in detectors reference
+  </Card>
+</CardGroup>

--- a/developer-guide/protect/observability.mdx
+++ b/developer-guide/protect/observability.mdx
@@ -1,0 +1,353 @@
+---
+title: 'Observability'
+description: 'Monitor Dome guardrails with OpenTelemetry, tracing, and logging.'
+---
+
+Dome is OpenTelemetry-compliant and integrates with popular observability platforms. This guide covers tracing, metrics, and logging setup.
+
+## Quick Setup
+
+Install with OpenTelemetry support:
+
+```bash
+pip install vijil-dome[opentelemetry]
+```
+
+## LLM Tracing Platforms
+
+### Weights & Biases Weave
+
+[Weave](https://weave-docs.wandb.ai/) is W&B's toolkit for tracing LLM applications.
+
+```python
+import weave
+from vijil_dome import Dome
+
+# Initialize Weave
+weave.init("my-project")
+
+# Create Dome and enable Weave tracing
+dome = Dome()
+dome.apply_decorator(weave.op)
+
+# Now all guard calls appear in Weave traces
+result = dome.guard_input("User message")
+```
+
+In your Weave dashboard, you'll see:
+- All `guard_input` and `guard_output` calls
+- Individual guard execution within each guardrail
+- Detector-level details for each guard
+
+### AgentOps
+
+[AgentOps](https://www.agentops.ai/) provides agent-focused observability.
+
+```python
+import os
+import agentops
+from vijil_dome import Dome
+
+# Initialize AgentOps
+agentops.init(os.getenv("AGENTOPS_API_KEY"))
+
+# Create Dome and enable AgentOps tracking
+dome = Dome()
+dome.apply_decorator(agentops.record_action())
+
+# Use with an AgentOps-tracked agent
+@agentops.track_agent("MyAgent")
+class MyAgent:
+    def chat(self, query: str):
+        input_scan = dome.guard_input(query)
+        if input_scan.is_safe():
+            response = self.call_llm(input_scan.guarded_response())
+            output_scan = dome.guard_output(response)
+            return output_scan.guarded_response()
+        return input_scan.guarded_response()
+
+# Run your agent
+agent = MyAgent()
+response = agent.chat("Hello!")
+
+# End session
+agentops.end_session("Success")
+```
+
+## OpenTelemetry Integration
+
+Dome works with any OpenTelemetry-compliant platform (Jaeger, Uptrace, Signoz, etc.).
+
+### Basic Setup
+
+```python
+from vijil_dome import Dome
+
+dome = Dome()
+
+# Instrument with your OpenTelemetry objects
+dome.instrument(
+    tracer=your_tracer,    # Optional: for tracing
+    meter=your_meter,      # Optional: for metrics
+    handlers=[your_handler] # Optional: for logging
+)
+```
+
+### Full Example with Jaeger
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.sdk.resources import Resource
+from vijil_dome import Dome
+
+# Set up tracer
+resource = Resource.create({"service.name": "my-agent"})
+provider = TracerProvider(resource=resource)
+jaeger_exporter = JaegerExporter(
+    agent_host_name="localhost",
+    agent_port=6831,
+)
+provider.add_span_processor(BatchSpanProcessor(jaeger_exporter))
+trace.set_tracer_provider(provider)
+
+tracer = trace.get_tracer(__name__)
+
+# Create and instrument Dome
+dome = Dome()
+dome.instrument(tracer=tracer)
+
+# All guard calls now create spans in Jaeger
+result = dome.guard_input("User message")
+```
+
+## Tracing
+
+When instrumented with a tracer, Dome creates spans for:
+
+- **Guardrail execution**: Top-level span for `guard_input` / `guard_output`
+- **Guard execution**: Nested span for each guard in the guardrail
+- **Detector execution**: Nested span for each detector in the guard
+
+Each span includes:
+- Input and output data
+- Execution time
+- Error information (if any)
+- Whether content was flagged
+
+### Span Hierarchy
+
+```
+guard_input
+├── security-guard
+│   ├── prompt-injection-mbert
+│   └── encoding-heuristics
+└── moderation-guard
+    └── moderation-flashtext
+```
+
+## Metrics
+
+When instrumented with a meter, Dome automatically tracks:
+
+| Metric | Description |
+|--------|-------------|
+| `requests` | Total requests to each component |
+| `flagged` | Requests flagged by each component |
+| `errors` | Errors encountered |
+| `latency` | Execution time |
+
+### Metric Naming
+
+Metrics follow the pattern: `[guardrail].[guard].[detector].[metric]`
+
+Examples:
+- `input_guardrail.security_guard.requests`
+- `input_guardrail.security_guard.prompt_injection_mbert.flagged`
+- `output_guardrail.latency`
+
+### Example: Prometheus
+
+```python
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
+from prometheus_client import start_http_server
+from vijil_dome import Dome
+
+# Start Prometheus server
+start_http_server(8000)
+
+# Set up meter
+reader = PrometheusMetricReader()
+provider = MeterProvider(metric_readers=[reader])
+metrics.set_meter_provider(provider)
+
+meter = metrics.get_meter(__name__)
+
+# Create and instrument Dome
+dome = Dome()
+dome.instrument(meter=meter)
+
+# Metrics are now available at http://localhost:8000
+```
+
+## Logging
+
+Dome logs to Python loggers under `vijil.dome`. Add handlers to capture logs:
+
+```python
+import logging
+from vijil_dome import Dome
+
+# Set up logging
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+
+# Create Dome with handler
+dome = Dome()
+dome.instrument(handlers=[handler])
+```
+
+### Log Levels
+
+| Level | What's Logged |
+|-------|---------------|
+| `DEBUG` | Initialization details, parameters |
+| `INFO` | Inputs and outputs from each component |
+| `WARNING` | Missing config, context window exceeded, timeouts |
+| `ERROR` | Handled exceptions during execution |
+| `CRITICAL` | Initialization failures, unhandled exceptions |
+
+### Structured Logging
+
+For JSON-structured logs:
+
+```python
+import logging
+import json
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record):
+        log_obj = {
+            "timestamp": self.formatTime(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if hasattr(record, 'extra'):
+            log_obj.update(record.extra)
+        return json.dumps(log_obj)
+
+handler = logging.StreamHandler()
+handler.setFormatter(JSONFormatter())
+
+dome = Dome()
+dome.instrument(handlers=[handler])
+```
+
+## Custom Metrics
+
+Add your own metrics alongside Dome's:
+
+```python
+from opentelemetry import metrics
+
+meter = metrics.get_meter(__name__)
+
+# Custom counters
+blocked_by_policy = meter.create_counter(
+    "agent.blocked_by_policy",
+    description="Requests blocked by guardrails"
+)
+
+guard_latency = meter.create_histogram(
+    "agent.guard_latency",
+    description="Guard execution latency"
+)
+
+def protected_chat(message: str):
+    import time
+    start = time.time()
+
+    result = dome.guard_input(message)
+
+    guard_latency.record(time.time() - start)
+
+    if not result.is_safe():
+        blocked_by_policy.add(1, {"guard": "input"})
+        return result.guarded_response()
+
+    # ... rest of agent logic
+```
+
+## Dashboard Examples
+
+### Grafana Dashboard
+
+Track key metrics:
+
+```
+# Blocked request rate
+sum(rate(input_guardrail_flagged[5m])) / sum(rate(input_guardrail_requests[5m]))
+
+# Average latency
+histogram_quantile(0.95, rate(input_guardrail_latency_bucket[5m]))
+
+# Error rate
+sum(rate(input_guardrail_errors[5m])) / sum(rate(input_guardrail_requests[5m]))
+```
+
+### Alerts
+
+Set up alerts for anomalies:
+
+```yaml
+# High block rate (potential attack)
+- alert: HighBlockRate
+  expr: sum(rate(input_guardrail_flagged[5m])) / sum(rate(input_guardrail_requests[5m])) > 0.5
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: High guardrail block rate detected
+
+# Guard errors
+- alert: GuardErrors
+  expr: sum(rate(input_guardrail_errors[5m])) > 0
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: Guardrail errors detected
+```
+
+## Best Practices
+
+1. **Always instrument in production**: Visibility is essential for security
+2. **Set appropriate log levels**: Use INFO for production, DEBUG for troubleshooting
+3. **Monitor block rates**: Sudden increases may indicate attacks
+4. **Track latency**: Ensure guards don't impact user experience
+5. **Alert on errors**: Guard failures should be investigated immediately
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Configuring Guardrails" icon="sliders" href="/developer-guide/protect/configuring-guardrails">
+    Guard configuration options
+  </Card>
+  <Card title="Using Guardrails" icon="shield" href="/developer-guide/protect/using-guardrails">
+    Runtime integration patterns
+  </Card>
+  <Card title="Custom Detectors" icon="wrench" href="/developer-guide/protect/custom-detectors">
+    Build custom detection methods
+  </Card>
+  <Card title="Protection Overview" icon="book" href="/developer-guide/protect/overview">
+    Dome architecture overview
+  </Card>
+</CardGroup>

--- a/developer-guide/protect/overview.mdx
+++ b/developer-guide/protect/overview.mdx
@@ -1,0 +1,211 @@
+---
+title: 'Protection Overview'
+description: 'Guard your agent at runtime with Dome guardrails.'
+---
+
+Evaluation catches vulnerabilities you know to test for. But attackers will try things you didn't anticipate—new prompt injection techniques, novel encoding tricks, social engineering patterns that emerge after your last evaluation.
+
+Dome is Vijil's runtime protection system. It intercepts every input and output, applies configurable guardrails, and blocks attacks before they reach your agent or your users. When Diamond identifies vulnerabilities you can't immediately fix, Dome provides defense-in-depth while you remediate.
+
+## How Dome Works
+
+Dome wraps your agent with configurable guardrails:
+
+<img src="/images/defense-flow.svg" alt="Dome defense flow showing input guardrail, agent, and output guardrail" style={{maxWidth: '600px', margin: '2rem auto', display: 'block'}} />
+
+| Component | Purpose |
+|-----------|---------|
+| **Guardrail** | Pipeline of guards (input or output) |
+| **Guard** | Group of detectors of one type |
+| **Detector** | Individual detection method |
+
+## Protection Types
+
+### Security Guards
+
+Detect and block adversarial attacks:
+
+| Detector | What It Catches |
+|----------|-----------------|
+| `prompt-injection-mbert` | Injected instructions in user input |
+| `prompt-injection-deberta-v3-base` | Advanced injection attempts |
+| `encoding-heuristics` | Base64, Unicode, and encoding attacks |
+| `security-embeddings` | Semantic similarity to known attacks |
+
+### Moderation Guards
+
+Filter harmful and inappropriate content:
+
+| Detector | What It Catches |
+|----------|-----------------|
+| `moderation-flashtext` | Fast keyword-based toxicity |
+| `moderation-deberta` | Neural toxicity classification |
+| `moderations-oai-api` | OpenAI Moderation API |
+| `moderation-llamaguard` | Llama Guard safety model |
+
+### Privacy Guards
+
+Prevent exposure of sensitive data:
+
+| Detector | What It Catches |
+|----------|-----------------|
+| `privacy-presidio` | PII (names, emails, SSN, etc.) |
+| `detect-secrets` | API keys, passwords, credentials |
+
+## Quick Start
+
+Install Dome:
+
+```bash
+pip install vijil-dome
+```
+
+Protect your agent with default guards:
+
+```python
+from vijil_dome import Dome
+
+dome = Dome()
+
+def protected_chat(user_message: str) -> str:
+    # Check input
+    input_scan = dome.guard_input(user_message)
+    if not input_scan.is_safe():
+        return input_scan.guarded_response()
+
+    # Call your agent
+    response = my_agent(input_scan.guarded_response())
+
+    # Check output
+    output_scan = dome.guard_output(response)
+    return output_scan.guarded_response()
+```
+
+The default configuration includes:
+- **Input**: Prompt injection detection, encoding heuristics, moderation
+- **Output**: Moderation, PII detection
+
+## Configuration Sources
+
+### Vijil Console
+
+Pull configuration from your registered agent:
+
+```python
+dome = Dome.create_from_vijil_agent(
+    agent_id="your-agent-id",
+    api_key=os.environ["VIJIL_API_KEY"]
+)
+```
+
+### Python Dictionary
+
+```python
+config = {
+    "input-guards": ["security-guard"],
+    "output-guards": ["privacy-guard"],
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-deberta-v3-base"]
+    },
+    "privacy-guard": {
+        "type": "privacy",
+        "methods": ["privacy-presidio"]
+    }
+}
+
+dome = Dome(config)
+```
+
+### TOML File
+
+```toml
+# dome-config.toml
+[guardrail]
+input-guards = ["security-guard"]
+output-guards = ["privacy-guard"]
+
+[security-guard]
+type = "security"
+methods = ["prompt-injection-deberta-v3-base"]
+
+[privacy-guard]
+type = "privacy"
+methods = ["privacy-presidio"]
+```
+
+```python
+dome = Dome("dome-config.toml")
+```
+
+## Scan Results
+
+Every guard call returns a result object:
+
+```python
+result = dome.guard_input(message)
+
+result.is_safe()           # True if no guards triggered
+result.guarded_response()  # Safe content or block message
+result.traceback()         # Detailed execution trace
+result.exec_time           # Processing time in ms
+```
+
+When content is flagged:
+- `is_safe()` returns `False`
+- `guarded_response()` returns a safe fallback message
+- The trace shows which detector flagged it and why
+
+## Framework Integrations
+
+Dome integrates with popular frameworks:
+
+| Framework | Integration |
+|-----------|-------------|
+| LangChain | `GuardrailRunnable` in LCEL chains |
+| Google ADK | `before_model_callback` / `after_model_callback` |
+| Custom | Direct `guard_input()` / `guard_output()` calls |
+
+See the [Framework Guides](/developer-guide/frameworks/langchain) for framework-specific examples.
+
+## Performance Options
+
+### Early Exit
+
+Stop processing when the first guard flags content:
+
+```python
+config = {
+    "input-early-exit": True,   # Faster rejection
+    "output-early-exit": False  # Complete logging
+}
+```
+
+### Parallel Execution
+
+Run guards simultaneously:
+
+```python
+config = {
+    "input-run-parallel": True,
+    "output-run-parallel": True
+}
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Configuring Guardrails" icon="sliders" href="/developer-guide/protect/configuring-guardrails">
+    Detailed guard configuration options
+  </Card>
+  <Card title="Using Guardrails" icon="shield" href="/developer-guide/protect/using-guardrails">
+    Runtime patterns and best practices
+  </Card>
+  <Card title="Custom Detectors" icon="wrench" href="/developer-guide/protect/custom-detectors">
+    Build your own detection methods
+  </Card>
+  <Card title="Observability" icon="eye" href="/developer-guide/protect/observability">
+    Monitoring and tracing setup
+  </Card>
+</CardGroup>

--- a/developer-guide/protect/using-guardrails.mdx
+++ b/developer-guide/protect/using-guardrails.mdx
@@ -1,0 +1,392 @@
+---
+title: 'Using Guardrails'
+description: 'Runtime patterns and best practices for Dome guardrails.'
+---
+
+This guide covers common patterns for integrating Dome guardrails into your agent, including sync/async usage, error handling, and production best practices.
+
+## Basic Integration Pattern
+
+The standard pattern wraps your agent with input and output guards:
+
+```python
+from vijil_dome import Dome
+from openai import OpenAI
+
+dome = Dome()
+client = OpenAI()
+
+def protected_chat(user_message: str) -> str:
+    # Step 1: Guard the input
+    input_scan = dome.guard_input(user_message)
+
+    if not input_scan.is_safe():
+        return input_scan.guarded_response()
+
+    # Step 2: Call your LLM with sanitized input
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": input_scan.guarded_response()}]
+    )
+    agent_response = response.choices[0].message.content
+
+    # Step 3: Guard the output
+    output_scan = dome.guard_output(agent_response)
+    return output_scan.guarded_response()
+```
+
+## Async Integration
+
+For async applications, use the async methods:
+
+```python
+import asyncio
+from vijil_dome import Dome
+from openai import AsyncOpenAI
+
+dome = Dome()
+client = AsyncOpenAI()
+
+async def protected_chat(user_message: str) -> str:
+    # Async input guard
+    input_scan = await dome.async_guard_input(user_message)
+
+    if not input_scan.is_safe():
+        return input_scan.guarded_response()
+
+    # Async LLM call
+    response = await client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": input_scan.guarded_response()}]
+    )
+    agent_response = response.choices[0].message.content
+
+    # Async output guard
+    output_scan = await dome.async_guard_output(agent_response)
+    return output_scan.guarded_response()
+```
+
+## Working with Scan Results
+
+### Checking Safety
+
+```python
+result = dome.guard_input(message)
+
+if result.is_safe():
+    # Process the message
+    sanitized = result.guarded_response()
+else:
+    # Handle blocked content
+    block_message = result.guarded_response()
+```
+
+### Inspecting Traces
+
+Get detailed information about what triggered:
+
+```python
+result = dome.guard_input(message)
+trace = result.traceback()
+
+# See which guards ran
+for guard_name, guard_result in trace.items():
+    if guard_result.get("flagged"):
+        print(f"Flagged by: {guard_name}")
+        print(f"Detector: {guard_result.get('detector')}")
+        print(f"Confidence: {guard_result.get('confidence')}")
+```
+
+### Execution Timing
+
+Monitor performance:
+
+```python
+result = dome.guard_input(message)
+print(f"Guard execution time: {result.exec_time}ms")
+```
+
+## Using Separate Guardrails
+
+For more control, get input and output guardrails separately:
+
+```python
+dome = Dome(config)
+input_guardrail, output_guardrail = dome.get_guardrails()
+
+# Use separately
+input_result = input_guardrail.guard(message)
+output_result = output_guardrail.guard(response)
+
+# Or async
+input_result = await input_guardrail.aguard(message)
+output_result = await output_guardrail.aguard(response)
+```
+
+## Custom Block Messages
+
+Override default block messages:
+
+```python
+config = {
+    "input-guards": ["security-guard"],
+    "blocked-response": "I'm sorry, I can't process that request.",
+
+    "security-guard": {
+        "type": "security",
+        "methods": ["prompt-injection-deberta-v3-base"],
+        "blocked-response": "Security check failed. Please rephrase your request."
+    }
+}
+
+dome = Dome(config)
+```
+
+## Error Handling
+
+Handle guard failures gracefully:
+
+```python
+def protected_chat(user_message: str) -> str:
+    try:
+        input_scan = dome.guard_input(user_message)
+
+        if not input_scan.is_safe():
+            return input_scan.guarded_response()
+
+        response = call_agent(input_scan.guarded_response())
+
+        output_scan = dome.guard_output(response)
+        return output_scan.guarded_response()
+
+    except Exception as e:
+        # Log the error
+        logger.error(f"Guard error: {e}")
+        # Return safe fallback
+        return "I'm experiencing technical difficulties. Please try again."
+```
+
+## Streaming Responses
+
+For streaming LLM responses, guard the complete response:
+
+```python
+async def protected_stream(user_message: str):
+    input_scan = await dome.async_guard_input(user_message)
+
+    if not input_scan.is_safe():
+        yield input_scan.guarded_response()
+        return
+
+    # Collect the full response
+    full_response = ""
+    async for chunk in stream_from_agent(input_scan.guarded_response()):
+        full_response += chunk
+
+    # Guard the complete response
+    output_scan = await dome.async_guard_output(full_response)
+
+    if output_scan.is_safe():
+        yield output_scan.guarded_response()
+    else:
+        yield output_scan.guarded_response()  # Returns block message
+```
+
+## Multi-Turn Conversations
+
+Guard each turn in a conversation:
+
+```python
+class ProtectedConversation:
+    def __init__(self):
+        self.dome = Dome()
+        self.history = []
+
+    def chat(self, user_message: str) -> str:
+        # Guard user input
+        input_scan = self.dome.guard_input(user_message)
+
+        if not input_scan.is_safe():
+            return input_scan.guarded_response()
+
+        # Add to history
+        self.history.append({
+            "role": "user",
+            "content": input_scan.guarded_response()
+        })
+
+        # Get response
+        response = call_agent_with_history(self.history)
+
+        # Guard output
+        output_scan = self.dome.guard_output(response)
+        safe_response = output_scan.guarded_response()
+
+        # Add safe response to history
+        self.history.append({
+            "role": "assistant",
+            "content": safe_response
+        })
+
+        return safe_response
+```
+
+## RAG Applications
+
+Guard both retrieval context and responses:
+
+```python
+def protected_rag(query: str) -> str:
+    # Guard the query
+    query_scan = dome.guard_input(query)
+    if not query_scan.is_safe():
+        return query_scan.guarded_response()
+
+    safe_query = query_scan.guarded_response()
+
+    # Retrieve context
+    context = retrieve_documents(safe_query)
+
+    # Optionally guard retrieved content
+    context_scan = dome.guard_output(context)
+    safe_context = context_scan.guarded_response()
+
+    # Generate response
+    response = generate_with_context(safe_query, safe_context)
+
+    # Guard final response
+    output_scan = dome.guard_output(response)
+    return output_scan.guarded_response()
+```
+
+## Tool-Using Agents
+
+Guard tool inputs and outputs:
+
+```python
+def protected_tool_agent(user_message: str) -> str:
+    # Guard user input
+    input_scan = dome.guard_input(user_message)
+    if not input_scan.is_safe():
+        return input_scan.guarded_response()
+
+    # Plan tool calls
+    tool_calls = plan_tool_calls(input_scan.guarded_response())
+
+    for tool_call in tool_calls:
+        # Guard tool input
+        tool_input_scan = dome.guard_input(tool_call.input)
+        if not tool_input_scan.is_safe():
+            continue  # Skip unsafe tool calls
+
+        # Execute tool
+        tool_output = execute_tool(tool_call.name, tool_input_scan.guarded_response())
+
+        # Guard tool output
+        tool_output_scan = dome.guard_output(tool_output)
+        tool_call.result = tool_output_scan.guarded_response()
+
+    # Generate final response
+    response = synthesize_response(tool_calls)
+
+    # Guard final output
+    output_scan = dome.guard_output(response)
+    return output_scan.guarded_response()
+```
+
+## Production Best Practices
+
+### Logging
+
+Log guard decisions for monitoring:
+
+```python
+import logging
+
+logger = logging.getLogger("dome")
+
+def protected_chat(user_message: str) -> str:
+    input_scan = dome.guard_input(user_message)
+
+    logger.info(f"Input guard: safe={input_scan.is_safe()}, time={input_scan.exec_time}ms")
+
+    if not input_scan.is_safe():
+        logger.warning(f"Input blocked: {input_scan.traceback()}")
+        return input_scan.guarded_response()
+
+    response = call_agent(input_scan.guarded_response())
+
+    output_scan = dome.guard_output(response)
+
+    logger.info(f"Output guard: safe={output_scan.is_safe()}, time={output_scan.exec_time}ms")
+
+    if not output_scan.is_safe():
+        logger.warning(f"Output blocked: {output_scan.traceback()}")
+
+    return output_scan.guarded_response()
+```
+
+### Metrics
+
+Track guard performance:
+
+```python
+from prometheus_client import Counter, Histogram
+
+input_blocked = Counter("dome_input_blocked_total", "Blocked inputs")
+output_blocked = Counter("dome_output_blocked_total", "Blocked outputs")
+guard_latency = Histogram("dome_guard_latency_seconds", "Guard latency")
+
+def protected_chat(user_message: str) -> str:
+    with guard_latency.time():
+        input_scan = dome.guard_input(user_message)
+
+    if not input_scan.is_safe():
+        input_blocked.inc()
+        return input_scan.guarded_response()
+
+    response = call_agent(input_scan.guarded_response())
+
+    with guard_latency.time():
+        output_scan = dome.guard_output(response)
+
+    if not output_scan.is_safe():
+        output_blocked.inc()
+
+    return output_scan.guarded_response()
+```
+
+### Configuration Management
+
+Use environment-specific configurations:
+
+```python
+import os
+
+def get_dome_config():
+    env = os.environ.get("ENVIRONMENT", "development")
+
+    if env == "production":
+        return Dome("config/dome-production.toml")
+    else:
+        return Dome("config/dome-development.toml")
+
+dome = get_dome_config()
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Configuring Guardrails" icon="sliders" href="/developer-guide/protect/configuring-guardrails">
+    Detailed guard configuration
+  </Card>
+  <Card title="Custom Detectors" icon="wrench" href="/developer-guide/protect/custom-detectors">
+    Build custom detection methods
+  </Card>
+  <Card title="Observability" icon="eye" href="/developer-guide/protect/observability">
+    OpenTelemetry integration
+  </Card>
+  <Card title="LangChain Integration" icon="link" href="/developer-guide/frameworks/langchain">
+    Use with LangChain
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -8,139 +8,187 @@
   },
   "description": "Harden during development, validate before deployment, defend in runtime, and continuously improve agents with reinforcement learning.",
   "colors": {
-    "primary": "#16A34A",
-    "light": "#07C983",
-    "dark": "#15803D"
+    "primary": "#DE1616",
+    "light": "#FF4444",
+    "dark": "#0247A9"
   },
+  "css": "/styles.css",
   "icons": {
     "library": "lucide"
   },
   "navigation": {
     "tabs": [
       {
-        "tab": "Vijil Docs",
+        "tab": "Concepts",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "concepts/welcome",
+              "concepts/what-is-vijil"
+            ]
+          },
+          {
+            "group": "Trust Score",
+            "pages": [
+              "concepts/trust-score/introduction",
+              "concepts/trust-score/reliability",
+              "concepts/trust-score/security",
+              "concepts/trust-score/safety"
+            ]
+          },
+          {
+            "group": "Evaluation",
+            "pages": [
+              "concepts/evaluation-components/introduction",
+              "concepts/evaluation-components/harness",
+              "concepts/evaluation-components/scenario",
+              "concepts/evaluation-components/probe",
+              "concepts/evaluation-components/detector"
+            ]
+          },
+          {
+            "group": "Defense",
+            "pages": [
+              "concepts/defense/introduction",
+              "concepts/defense/guardrail",
+              "concepts/defense/guard",
+              "concepts/defense/detector",
+              "concepts/defense/observe"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "concepts/glossary",
+              "concepts/component-reference",
+              "concepts/release-notes"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Agent Owner Guide",
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["get-started/welcome", "get-started/quickstart"]
+            "pages": [
+              "owner-guide/getting-started/introduction",
+              "owner-guide/getting-started/enterprise-deployment",
+              "owner-guide/getting-started/account-setup",
+              "owner-guide/getting-started/quick-start"
+            ]
           },
           {
-            "group": "Core Concepts",
+            "group": "Register Agents",
             "pages": [
-              "core-concepts/introduction",
+              "owner-guide/register-agents/registering-agents"
+            ]
+          },
+          {
+            "group": "Simulate Environment",
+            "pages": [
+              "owner-guide/simulate-environment/personas",
+              "owner-guide/simulate-environment/policies",
               {
-                "group": "Dimensions of Trust",
-                "icon": "ruler-dimension-line",
-                "expanded": true,
+                "group": "Specifying Harnesses",
                 "pages": [
-                  "core-concepts/dimensions/introduction",
-                  "core-concepts/dimensions/reliability",
-                  "core-concepts/dimensions/safety",
-                  "core-concepts/dimensions/security"
-                ]
-              },
-              {
-                "group": "Trust Score Components",
-                "icon": "handshake",
-                "expanded": true,
-                "pages": [
-                  "core-concepts/components/introduction",
-                  "core-concepts/components/harness",
-                  "core-concepts/components/scenario",
-                  "core-concepts/components/probe",
-                  "core-concepts/components/detector",
-                  "core-concepts/components/guard",
-                  "core-concepts/components/guardrail"
+                  "owner-guide/simulate-environment/harnesses/trust-score",
+                  "owner-guide/simulate-environment/custom-harnesses"
                 ]
               }
             ]
           },
           {
-            "group": "Manage Agents",
+            "group": "Run Evaluations",
             "pages": [
-              "manage-agents/introduction",
-              {
-                "group": "Integrations",
-                "icon": "blocks",
-                "expanded": true,
-                "pages": [
-                  "manage-agents/integrations/vertex",
-                  "manage-agents/integrations/digitalocean",
-                  "manage-agents/integrations/bedrock",
-                  "manage-agents/integrations/custom",
-                  "manage-agents/integrations/local",
-                  "manage-agents/integrations/platform"
-                ]
-              }
+              "owner-guide/run-evaluations/running-evaluations",
+              "owner-guide/run-evaluations/understanding-results"
+            ]
+          },
+          {
+            "group": "Protect in Production",
+            "pages": [
+              "owner-guide/protect-in-production/configuring-guardrails",
+              "owner-guide/protect-in-production/deploying-dome",
+              "owner-guide/protect-in-production/observability"
+            ]
+          },
+          {
+            "group": "Audit Agent Behavior",
+            "pages": [
+              "owner-guide/audit-agent-behavior/quantifying-risk",
+              "owner-guide/audit-agent-behavior/operational-readiness"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Agent Developer Guide",
+        "groups": [
+          {
+            "group": "Get Started",
+            "pages": [
+              "developer-guide/getting-started/introduction",
+              "developer-guide/getting-started/installation",
+              "developer-guide/getting-started/authentication",
+              "developer-guide/getting-started/quickstart"
+            ]
+          },
+          {
+            "group": "Use Frameworks",
+            "pages": [
+              "developer-guide/frameworks/langchain",
+              "developer-guide/frameworks/google-adk",
+              "developer-guide/frameworks/custom-agents"
+            ]
+          },
+          {
+            "group": "Evaluate Agents",
+            "pages": [
+              "developer-guide/evaluate/overview",
+              "developer-guide/evaluate/running-evaluations",
+              "developer-guide/evaluate/understanding-results",
+              "developer-guide/evaluate/custom-harnesses",
+              "developer-guide/evaluate/cloud-providers"
             ]
           },
           {
             "group": "Protect Agents",
-            "pages": ["protect-agents/introduction"]
-          },
-          {
-            "group": "Evaluate Agents",
-            "pages": ["evaluate-agents/introduction"]
-          },
-          {
-            "group": "Tutorials",
             "pages": [
-              "tutorials/manage-api-keys",
-              "tutorials/manage-agents",
-              {
-                "group": "Protect Agents",
-                "icon": "shield-check",
-                "pages": [
-                  "tutorials/protect-agents/setup-dome",
-                  "tutorials/protect-agents/setup-guards",
-                  "tutorials/protect-agents/configuring-guardrails",
-                  "tutorials/protect-agents/using-guardrails",
-                  "tutorials/protect-agents/domed-clients",
-                  "tutorials/protect-agents/langchain",
-                  "tutorials/protect-agents/adk",
-                  "tutorials/protect-agents/custom-detectors",
-                  "tutorials/protect-agents/observability"
-                ]
-              },
-              {
-                "group": "Evaluate Agents",
-                "icon": "glasses",
-                "pages": [
-                  "tutorials/evaluate-agents/setup-evaluate",
-                  "tutorials/evaluate-agents/evaluations",
-                  "tutorials/evaluate-agents/owasp",
-                  "tutorials/evaluate-agents/rag",
-                  "tutorials/evaluate-agents/detections",
-                  "tutorials/evaluate-agents/custom-harnesses",
-                  "tutorials/evaluate-agents/local-agent-evaluation",
-                  "tutorials/evaluate-agents/reports",
-                  "tutorials/evaluate-agents/cicd",
-                  {
-                    "group": "Enterprise Deployment of Evaluate",
-                    "expanded": true,
-                    "pages": [
-                      "tutorials/evaluate-agents/enterprise/introduction",
-                      "tutorials/evaluate-agents/enterprise/prerequisites",
-                      "tutorials/evaluate-agents/enterprise/deployment"
-                    ]
-                  }
-                ]
-              }
+              "developer-guide/protect/overview",
+              "developer-guide/protect/configuring-guardrails",
+              "developer-guide/protect/using-guardrails",
+              "developer-guide/protect/custom-detectors",
+              "developer-guide/protect/observability"
             ]
           },
           {
-            "group": "References",
+            "group": "Deploy with CI/CD",
             "pages": [
-              "references/glossary",
-              "references/release-notes",
-              {
-                "group": "Python Client",
-                "icon": "worm",
-                "pages": [
-                  "references/python-client/introduction",
-                  "references/python-client/client"
-                ]
-              }
+              "developer-guide/cicd/overview",
+              "developer-guide/cicd/github-actions",
+              "developer-guide/cicd/gitlab-ci",
+              "developer-guide/cicd/testing-strategies"
+            ]
+          },
+          {
+            "group": "Deploy On-Premises",
+            "pages": [
+              "developer-guide/enterprise/overview",
+              "developer-guide/enterprise/self-hosted",
+              "developer-guide/enterprise/prerequisites",
+              "developer-guide/enterprise/configuration"
+            ]
+          },
+          {
+            "group": "API Reference",
+            "pages": [
+              "developer-guide/api/overview",
+              "developer-guide/api/python-client",
+              "developer-guide/api/evaluations-api",
+              "developer-guide/api/agents-api",
+              "developer-guide/api/dome-api"
             ]
           }
         ]
@@ -165,31 +213,15 @@
     ],
     "primary": {
       "type": "button",
-      "label": "Dashboard",
-      "href": "https://dashboard.mintlify.com"
+      "label": "Console",
+      "href": "https://console.vijil.ai"
     }
   },
-  "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "chatgpt",
-      "claude",
-      "perplexity",
-      "mcp",
-      "cursor",
-      "vscode"
-    ]
-  },
-  "footer": {
+    "footer": {
     "socials": {
       "website": "https://vijil.ai",
       "github": "https://github.com/vijilAI/",
       "linkedin": "https://www.linkedin.com/company/vijil"
     }
-  },
-  "banner": {
-    "content": "🚀 Welcome to Vijil Documentation!",
-    "dismissible": true
   }
 }

--- a/images/enterprise-architecture.svg
+++ b/images/enterprise-architecture.svg
@@ -1,0 +1,138 @@
+<svg viewBox="0 0 700 450" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter id="pencil" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.04" numOctaves="5" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.5" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+  </defs>
+
+  <style>
+    .label-text {
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      font-size: 13px;
+      font-weight: 500;
+    }
+    .small-text {
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      font-size: 10px;
+      fill: #666;
+    }
+    .section-label {
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      font-size: 11px;
+      font-weight: 600;
+      fill: #666;
+    }
+  </style>
+
+  <!-- Customer Infrastructure Boundary -->
+  <rect x="30" y="30" width="640" height="280" rx="12"
+        fill="none" stroke="#666" stroke-width="2" stroke-dasharray="8,4" filter="url(#pencil)"/>
+  <text x="50" y="55" class="section-label">YOUR INFRASTRUCTURE</text>
+
+  <!-- Kubernetes Cluster -->
+  <rect x="50" y="70" width="400" height="160" rx="8"
+        fill="#f8fafc" stroke="#94a3b8" stroke-width="2" filter="url(#pencil)"/>
+  <text x="70" y="95" class="section-label">KUBERNETES CLUSTER</text>
+
+  <!-- Diamond -->
+  <rect x="70" y="110" width="110" height="50" rx="18"
+        fill="#DE1616" stroke="#DE1616" stroke-width="2" filter="url(#pencil)"/>
+  <text x="125" y="140" text-anchor="middle" class="label-text" fill="white">Diamond</text>
+  <text x="125" y="175" text-anchor="middle" class="small-text">Evaluation</text>
+
+  <!-- Dome -->
+  <rect x="200" y="110" width="110" height="50" rx="18"
+        fill="#0247A9" stroke="#0247A9" stroke-width="2" filter="url(#pencil)"/>
+  <text x="255" y="140" text-anchor="middle" class="label-text" fill="white">Dome</text>
+  <text x="255" y="175" text-anchor="middle" class="small-text">Protection</text>
+
+  <!-- Console -->
+  <rect x="330" y="110" width="100" height="50" rx="18"
+        fill="white" stroke="#0247A9" stroke-width="2" filter="url(#pencil)"/>
+  <text x="380" y="140" text-anchor="middle" class="label-text" fill="#0247A9">Console</text>
+  <text x="380" y="175" text-anchor="middle" class="small-text">Web UI</text>
+
+  <!-- Connection lines from components to data stores -->
+  <line x1="125" y1="195" x2="125" y2="250" stroke="#94a3b8" stroke-width="2" filter="url(#pencil)"/>
+  <line x1="255" y1="195" x2="255" y2="250" stroke="#94a3b8" stroke-width="2" filter="url(#pencil)"/>
+  <line x1="380" y1="195" x2="380" y2="250" stroke="#94a3b8" stroke-width="2" filter="url(#pencil)"/>
+
+  <!-- Horizontal connector line -->
+  <line x1="125" y1="250" x2="380" y2="250" stroke="#94a3b8" stroke-width="2" filter="url(#pencil)"/>
+  <line x1="250" y1="250" x2="250" y2="280" stroke="#94a3b8" stroke-width="2" filter="url(#pencil)"/>
+
+  <!-- Data Stores Section -->
+  <rect x="50" y="250" width="400" height="50" rx="8"
+        fill="#fef3c7" stroke="#f59e0b" stroke-width="1" filter="url(#pencil)"/>
+
+  <!-- PostgreSQL -->
+  <rect x="70" y="260" width="90" height="30" rx="8"
+        fill="white" stroke="#f59e0b" stroke-width="1" filter="url(#pencil)"/>
+  <text x="115" y="280" text-anchor="middle" class="small-text" fill="#92400e">PostgreSQL</text>
+
+  <!-- OpenSearch -->
+  <rect x="180" y="260" width="90" height="30" rx="8"
+        fill="white" stroke="#f59e0b" stroke-width="1" filter="url(#pencil)"/>
+  <text x="225" y="280" text-anchor="middle" class="small-text" fill="#92400e">OpenSearch</text>
+
+  <!-- S3 -->
+  <rect x="290" y="260" width="70" height="30" rx="8"
+        fill="white" stroke="#f59e0b" stroke-width="1" filter="url(#pencil)"/>
+  <text x="325" y="280" text-anchor="middle" class="small-text" fill="#92400e">S3</text>
+
+  <!-- External Services -->
+  <text x="490" y="95" class="section-label">EXTERNAL</text>
+
+  <!-- Auth0 -->
+  <rect x="480" y="110" width="90" height="40" rx="12"
+        fill="white" stroke="#22c55e" stroke-width="2" filter="url(#pencil)"/>
+  <text x="525" y="135" text-anchor="middle" class="label-text" fill="#16a34a">Auth0</text>
+
+  <!-- Arrow from Console to Auth0 -->
+  <line x1="430" y1="135" x2="475" y2="135" stroke="#22c55e" stroke-width="2" filter="url(#pencil)"/>
+  <polygon points="480,135 470,130 470,140" fill="#22c55e" filter="url(#pencil)"/>
+
+  <!-- LLM Providers -->
+  <rect x="480" y="170" width="90" height="40" rx="12"
+        fill="white" stroke="#8b5cf6" stroke-width="2" filter="url(#pencil)"/>
+  <text x="525" y="195" text-anchor="middle" class="label-text" fill="#7c3aed">LLMs</text>
+
+  <!-- Arrow from Diamond to LLMs (for agent testing) -->
+  <line x1="180" y1="125" x2="200" y2="125" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="4,2" filter="url(#pencil)"/>
+
+  <!-- Your Agents -->
+  <rect x="480" y="230" width="170" height="70" rx="12"
+        fill="white" stroke="#DE1616" stroke-width="2" filter="url(#pencil)"/>
+  <text x="565" y="255" text-anchor="middle" class="label-text" fill="#DE1616">Your Agents</text>
+  <text x="565" y="275" text-anchor="middle" class="small-text">Evaluated by Diamond</text>
+  <text x="565" y="290" text-anchor="middle" class="small-text">Protected by Dome</text>
+
+  <!-- Arrow from Diamond to Agents -->
+  <line x1="180" y1="135" x2="475" y2="250" stroke="#DE1616" stroke-width="2" filter="url(#pencil)"/>
+  <polygon points="480,252 468,248 472,258" fill="#DE1616" filter="url(#pencil)"/>
+
+  <!-- Arrow from Dome to Agents -->
+  <line x1="310" y1="135" x2="475" y2="265" stroke="#0247A9" stroke-width="2" filter="url(#pencil)"/>
+  <polygon points="480,267 468,260 470,272" fill="#0247A9" filter="url(#pencil)"/>
+
+  <!-- Legend -->
+  <text x="50" y="350" class="section-label">LEGEND</text>
+
+  <rect x="50" y="365" width="20" height="12" rx="4" fill="#DE1616" filter="url(#pencil)"/>
+  <text x="80" y="375" class="small-text">Evaluation (Diamond)</text>
+
+  <rect x="200" y="365" width="20" height="12" rx="4" fill="#0247A9" filter="url(#pencil)"/>
+  <text x="230" y="375" class="small-text">Protection (Dome)</text>
+
+  <rect x="350" y="365" width="20" height="12" rx="4" fill="white" stroke="#f59e0b" stroke-width="1" filter="url(#pencil)"/>
+  <text x="380" y="375" class="small-text">Data Stores</text>
+
+  <rect x="480" y="365" width="20" height="12" rx="4" fill="white" stroke="#22c55e" stroke-width="1" filter="url(#pencil)"/>
+  <text x="510" y="375" class="small-text">External Services</text>
+
+  <!-- Data flow note -->
+  <text x="50" y="410" class="small-text">All data stays within your infrastructure boundary.</text>
+  <text x="50" y="425" class="small-text">External connections: Auth0 (authentication), LLM providers (your agents' models).</text>
+
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1 @@
+/* Custom styles for Vijil documentation */


### PR DESCRIPTION
## Summary
- Add Agent Developer Guide tab with SDK-focused workflows
- Getting Started: introduction, installation, authentication, quickstart with LocalAgentExecutor
- Use Frameworks: LangChain, Google ADK, custom Python agents
- Evaluate Agents: overview with SVG diagram, running evaluations, understanding results, custom harnesses, cloud providers
- Protect Agents: overview with SVG diagram, configuring guardrails, using guardrails, custom detectors, observability
- Deploy with CI/CD: overview, GitHub Actions, GitLab CI, testing strategies
- Deploy On-Premises: overview with architecture SVG, self-hosted guide, prerequisites, configuration
- API Reference: AWS-style formatting with Request/Response Syntax, Parameters, Errors, Examples
  - Python SDK Reference
  - Evaluations API
  - Agents API
  - Dome API
- Update docs.json with complete 3-tab navigation structure
- Add enterprise-architecture.svg diagram
- Add styles.css

## Test plan
- [ ] Verify all pages render correctly in Mintlify
- [ ] Check SVG diagrams display properly
- [ ] Verify API reference code blocks render correctly
- [ ] Test internal links between guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)