### PR TITLE
P1 Fix navigation issue for Dome Containerized Deployment

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -38,7 +38,9 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["concepts/welcome"]
+            "pages": [
+              "concepts/welcome"
+            ]
           },
           {
             "group": "Trust Score",
@@ -92,7 +94,9 @@
           },
           {
             "group": "Reference",
-            "pages": ["concepts/glossary"]
+            "pages": [
+              "concepts/glossary"
+            ]
           }
         ]
       },
@@ -108,7 +112,9 @@
           },
           {
             "group": "Register Agents",
-            "pages": ["owner-guide/register-agents/registering-agents"]
+            "pages": [
+              "owner-guide/register-agents/registering-agents"
+            ]
           },
           {
             "group": "Build an Evaluation Environment",
@@ -136,8 +142,7 @@
             "pages": [
               "owner-guide/protect-in-production/configuring-guardrails",
               "owner-guide/protect-in-production/deploying-dome",
-              "owner-guide/protect-in-production/observability",
-              "tutorials/protect-agents/dome-containerized-deployment"
+              "owner-guide/protect-in-production/observability"
             ]
           }
         ]
@@ -188,7 +193,10 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["legacy/get-started/welcome", "legacy/get-started/quickstart"]
+            "pages": [
+              "legacy/get-started/welcome",
+              "legacy/get-started/quickstart"
+            ]
           },
           {
             "group": "Core Concepts",
@@ -253,7 +261,9 @@
           },
           {
             "group": "Evaluate Agents",
-            "pages": ["legacy/evaluate-agents/introduction"]
+            "pages": [
+              "legacy/evaluate-agents/introduction"
+            ]
           },
           {
             "group": "Tutorials",

--- a/docs.json
+++ b/docs.json
@@ -136,7 +136,8 @@
             "pages": [
               "owner-guide/protect-in-production/configuring-guardrails",
               "owner-guide/protect-in-production/deploying-dome",
-              "owner-guide/protect-in-production/observability"
+              "owner-guide/protect-in-production/observability",
+              "tutorials/protect-agents/dome-containerized-deployment"
             ]
           }
         ]
@@ -176,7 +177,8 @@
               "developer-guide/protect/configuring-guardrails",
               "developer-guide/protect/using-guardrails",
               "developer-guide/protect/custom-detectors",
-              "developer-guide/protect/observability"
+              "developer-guide/protect/observability",
+              "tutorials/protect-agents/dome-containerized-deployment"
             ]
           }
         ]


### PR DESCRIPTION
I edited `docs.json` to include "`tutorials/protect-agents/dome-containerized-deployment`" in the navigation sidebar so it's readily accessible. The page is added to the "Protect Agents" section of both the Agent Owner's Guide and Agent Developer Guide tabs.