### PR TITLE
Removed the Integration section from WIP

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -161,14 +161,6 @@
             ]
           },
           {
-            "group": "Integrations",
-            "pages": [
-              "developer-guide/frameworks/langchain",
-              "developer-guide/frameworks/google-adk",
-              "developer-guide/frameworks/custom-agents"
-            ]
-          },
-          {
             "group": "Evaluate Agents",
             "pages": [
               "developer-guide/evaluate/overview",


### PR DESCRIPTION
Removed the "Integrations" group (along with the Langchain, Google adk, and Custom agents pages) from the Developer Guide section in `docs.json`.